### PR TITLE
Adding expandable list of portal notifs

### DIFF
--- a/client/src/components/SideMenu/NotificationsTab.js
+++ b/client/src/components/SideMenu/NotificationsTab.js
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { Grid, List, Button } from "@material-ui/core";
+import useStyles from "../SideMenu/styles";
+import NotificationFactory from "../SideMenu/NotificationFactory";
+
+export default function NotificationsTab(props) {
+  const classes = useStyles();
+
+  // siempre muestra 5 notificaciones al abrir la barra de notificaciones
+  const [isExtended, setIsExtended] = useState(false);
+
+  const toggleExpansion = (e) => {
+    e.preventDefault();
+    setIsExtended(!isExtended);
+  };
+
+  if (props.notificaciones.length === 0) return null;
+  else if (props.notificaciones.length <= 5) {
+    return (
+      <Grid container className={classes.notificationsPaper}>
+        <List anchor="right">
+          {props.notificaciones.map((notif) => (
+            <NotificationFactory component={notif} />
+          ))}
+        </List>
+      </Grid>
+    );
+  } else {
+    let shownNotifications = [];
+    if (!isExtended) {
+      for (let i = 0; i < 5; i++) {
+        shownNotifications.push(props.notificaciones[i]);
+      }
+    } else {
+      shownNotifications = props.notificaciones;
+    }
+
+    return (
+      <Grid container className={classes.notificationsPaper}>
+        <List anchor="right">
+          {shownNotifications.map((notif) => (
+            <NotificationFactory component={notif} />
+          ))}
+        </List>
+        <Button
+          onClick={toggleExpansion}
+          color="primary"
+          className={classes.viewMoreOrLessNotifsButton}
+        >
+          {isExtended
+            ? "Ver menos"
+            : `Ver más (${props.notificaciones.length - 5})`}
+        </Button>
+      </Grid>
+    );
+  }
+}

--- a/client/src/components/SideMenu/NotificationsTab.js
+++ b/client/src/components/SideMenu/NotificationsTab.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Grid, List, Button } from "@material-ui/core";
 import useStyles from "../SideMenu/styles";
 import NotificationFactory from "../SideMenu/NotificationFactory";
+import NightsStayIcon from "@material-ui/icons/NightsStay";
 
 export default function NotificationsTab(props) {
   const classes = useStyles();
@@ -14,8 +15,16 @@ export default function NotificationsTab(props) {
     setIsExtended(!isExtended);
   };
 
-  if (props.notificaciones.length === 0) return null;
-  else if (props.notificaciones.length <= 5) {
+  if (props.notificaciones.length === 0) {
+    return (
+      <Grid container className={classes.notificationsPaper}>
+        <List anchor="right" className={classes.noNotifications}>
+          <NightsStayIcon />
+          <text>Usted no tiene notificaciones</text>
+        </List>
+      </Grid>
+    );
+  } else if (props.notificaciones.length <= 5) {
     return (
       <Grid container className={classes.notificationsPaper}>
         <List anchor="right">

--- a/client/src/components/SideMenu/SideMenu.js
+++ b/client/src/components/SideMenu/SideMenu.js
@@ -164,7 +164,7 @@ const SideMenu = () => {
     <div>
       <AppBar
         position="absolute"
-        color="white"
+        color="transparent"
         className={clsx(classes.appBar, drawerOpen && classes.appBarShift)}
       >
         <Toolbar className="toolbar">

--- a/client/src/components/SideMenu/SideMenu.js
+++ b/client/src/components/SideMenu/SideMenu.js
@@ -8,7 +8,6 @@ import {
   AppBar,
   Toolbar,
   Typography,
-  Grid,
 } from "@material-ui/core";
 import { ChevronLeft, Menu, Notifications } from "@material-ui/icons";
 import "../../styles/globalStyles.css";
@@ -17,6 +16,7 @@ import ListItems from "../SideMenu/ListItems";
 import ListItemsAdmin from "../SideMenu/ListItemsAdmin";
 import NotificationFactory from "../SideMenu/NotificationFactory";
 import NOTIFICATION_TYPES from "../utils/NotificationTypes";
+import NotificationsTab from "../SideMenu/NotificationsTab";
 import axios from "axios";
 
 const SideMenu = () => {
@@ -59,7 +59,7 @@ const SideMenu = () => {
         });
     };
     obtenerNotificaciones();
-  }, []);
+  }, [notificationsOpen]);
 
   const formatNotifications = (rawNotifications) => {
     const notifications = rawNotifications
@@ -146,6 +146,13 @@ const SideMenu = () => {
     isRead: false,
   };
 
+  // useEffect(() => {
+  //   const obtenerNotificaciones = () => {
+  //     setNotificaciones([first, second, third, fourth, fifth, sixth]);
+  //   };
+  //   obtenerNotificaciones();
+  // }, [notificationsOpen]);
+
   const sampleNotif1 = <NotificationFactory component={first} />;
   const sampleNotif2 = <NotificationFactory component={second} />;
   const sampleNotif3 = <NotificationFactory component={third} />;
@@ -189,15 +196,7 @@ const SideMenu = () => {
           </IconButton>
         </Toolbar>
         {notificationsOpen && (
-          <Grid container className={classes.notificationsPaper}>
-            <List anchor="right">
-              {notificaciones.length
-                ? notificaciones.map((notif) => (
-                    <NotificationFactory component={notif} />
-                  ))
-                : null}
-            </List>
-          </Grid>
+          <NotificationsTab notificaciones={notificaciones} />
         )}
       </AppBar>
       <Drawer anchor="left" open={drawerOpen}>

--- a/client/src/components/SideMenu/SideMenu.js
+++ b/client/src/components/SideMenu/SideMenu.js
@@ -160,12 +160,11 @@ const SideMenu = () => {
   const sampleNotif5 = <NotificationFactory component={fifth} />;
   const sampleNotif6 = <NotificationFactory component={sixth} />;
 
-  // TODO: Limit visibility to 5 notifications
   return (
     <div>
       <AppBar
         position="absolute"
-        color="transparent"
+        color="white"
         className={clsx(classes.appBar, drawerOpen && classes.appBarShift)}
       >
         <Toolbar className="toolbar">

--- a/client/src/components/SideMenu/styles.js
+++ b/client/src/components/SideMenu/styles.js
@@ -2,6 +2,7 @@ import { makeStyles } from "@material-ui/core";
 import { orange } from "@material-ui/core/colors";
 const drawerWidth = 240;
 const notificationsTabWidth = 396;
+const notificationsTabHeight = 480;
 const useStyles = makeStyles((theme) => ({
    root: {
       display: "flex",
@@ -70,6 +71,8 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: "white",
       position: "static",
       width: notificationsTabWidth,
+      maxHeight: notificationsTabHeight,
+      overflow: "scroll",
       boxShadow: "0px 2px 4px -1px",
    },
    notifReadIcon: {
@@ -77,6 +80,9 @@ const useStyles = makeStyles((theme) => ({
    },
    unreadNotif: {
       backgroundColor: "#f0d2bd",
+   },
+   viewMoreOrLessNotifsButton: {
+      margin: "0px auto"
    },
    content: {
       flexGrow: 1,

--- a/client/src/components/SideMenu/styles.js
+++ b/client/src/components/SideMenu/styles.js
@@ -75,6 +75,10 @@ const useStyles = makeStyles((theme) => ({
       overflow: "scroll",
       boxShadow: "0px 2px 4px -1px",
    },
+   noNotifications: {
+      display: "flex",
+      margin: "0px auto"
+   },
    notifReadIcon: {
       marginRight: 0,
    },

--- a/client/src/components/pages/MiPerfil.js
+++ b/client/src/components/pages/MiPerfil.js
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme) => ({
       minWidth: 275,
       width: "80%",
       margin: "auto",
-      marginTop: "40px",
+      marginTop: "80px",
    },
    titlePer: {
       flexGrow: 1,

--- a/client/src/styles/globalStyles.css
+++ b/client/src/styles/globalStyles.css
@@ -277,7 +277,7 @@
    top: 40px;
    display: flex;
    justify-content: flex-end;
-   margin-right: 2em;
+   margin-right: 5em;
 }
 
 .editIconContainer {

--- a/client/src/styles/globalStyles.css
+++ b/client/src/styles/globalStyles.css
@@ -176,6 +176,7 @@
 
 .toolbar {
    padding-right: 24;
+   background-color: white;
 }
 
 .toolbarIcon {
@@ -274,7 +275,7 @@
 .fabIcon {
    z-index: 1000000;
    position: relative;
-   top: 40px;
+   top: 10px;
    display: flex;
    justify-content: flex-end;
    margin-right: 5em;


### PR DESCRIPTION
Este PR agrega las siguientes funcionalidades que mejoran la usabilidad de la barra de notificaciones:
- Si hay 5 o menos notificaciones, se muestran todas.
- Si hay de 6 a 10 (inclusive) notificaciones, se muestran las primeras 5 y un botón de "Ver más" permite ver las restantes, además de informar cuántas están escondidas. Al ver todas, se muestra un botón para esconder las que previamente estaban ocultas y se vuelven a ver únicamente las primeras 5.
- Scroll para las notificaciones y tamaño máximo fijo de menu desplegable.

Detalle extra: La llamada al backend se hace cada que se abren/esconden las notificaciones en lugar de sólo al mostrar la página inicialmente.

Para probar la funcionalidad con datos de prueba, _comenta_ el `useEffect` que hace la llamada al backend y quita los comentarios del `useEffect` de prueba.