### PR TITLE
Send notification mail for NUEVA_PARTICIPACION

### DIFF
--- a/server/services/MailQueue.js
+++ b/server/services/MailQueue.js
@@ -1,11 +1,15 @@
 const Queue = require("bull");
 const redisConfig = require("../config/redisConfig");
-const { NUEVA_OPORTUNIDAD } = require("../utils/NotificationTypes");
+const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION } = require("../utils/NotificationTypes");
 const mailService = require("./MailService");
 
 const mailQueue = new Queue("mail-queue", { redisConfig });
 
 mailQueue.process(NUEVA_OPORTUNIDAD, (job) => {
+  return mailService.sendEmail(job.data);
+});
+
+mailQueue.process(NUEVA_PARTICIPACION, (job) => {
   return mailService.sendEmail(job.data);
 });
 

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -1,5 +1,5 @@
 const nodemailer = require("nodemailer");
-const notificationTypes = require("../utils/NotificationTypes");
+const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION } = require("../utils/NotificationTypes");
 
 const mailService = {};
 
@@ -45,7 +45,7 @@ mailService.buildMailContent = (tipoNotificacion, rfp) => {
     let mailOptions = {};
 
     switch (tipoNotificacion) {
-      case notificationTypes.NUEVA_OPORTUNIDAD:
+      case NUEVA_OPORTUNIDAD:
         mailOptions.subject = "Nueva Oportunidad Comercial";
         mailOptions.text = `te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:
 
@@ -65,10 +65,7 @@ Datos de contacto
 Nombre: ${rfp.nombrecliente}
 Posición: ${rfp.posicioncliente}
 Teléfono: ${rfp.telefono}
-Correo electrónico: ${rfp.email}
-
-Gracias,
-Notificaciones de CSOFTMTY`;
+Correo electrónico: ${rfp.email}`;
 
         mailOptions.html = `te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:</p>
           <p><b>Nombre de la Oportunidad Comercial:</b> ${rfp.nombreOportunidad}<br>
@@ -86,15 +83,24 @@ Notificaciones de CSOFTMTY`;
           <p><b>Nombre:</b> ${rfp.nombrecliente}<br>
           <b>Posición:</b> ${rfp.posicioncliente}<br>
           <b>Teléfono:</b> ${rfp.telefono}<br>
-          <b>Correo electrónico:</b> ${rfp.email}</p>
-          <p>Gracias,<br>
-          Notificaciones de CSOFTMTY</p>
-          <img src="https://www.csoftmty.org/assets/images/header/logo.png" alt="logo_csoftmty"/>`;
+          <b>Correo electrónico:</b> ${rfp.email}</p>`;
+        break;
+      
+      case NUEVA_PARTICIPACION:
+        mailOptions.subject = "Un socio de CSOFTMTY ha aplicado a tu Oportunidad Comercial";
+        mailOptions.text = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".`
+
+        mailOptions.html = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".</p>`
         break;
       
       default:
         reject("Invalid notificationType");
     }
+    mailOptions.text += "\n\nGracias,\nNotificaciones de CSOFTMTY";
+    mailOptions.html += `<p>Gracias,<br>
+      Notificaciones de CSOFTMTY</p>
+      <img src="https://www.csoftmty.org/assets/images/header/logo.png" alt="logo_csoftmty"/>`
+    
     resolve(mailOptions);
   });
 };

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -232,11 +232,14 @@ notificationService.notificacionNuevaParticipacion = (participacion) => {
   return new Promise((resolve, reject) => {
     saveDbNotificacionNuevaParticipacion(participacion)
       .then((resp) => {
+        resolve(resp);
+        /*
         mailNuevaParticipacion(participacion)
           .then((respMail) => {
             resolve(respMail);
           })
           .catch((error) => reject(error));
+        */
       })
       .catch((error) => reject(error));
   });

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -81,7 +81,7 @@ const mailTodosSocios = function (tipoNotificacion, rfp) {
                   email: socio.email,
                 }
               };
-              mailQueue.add(NUEVA_OPORTUNIDAD, jobMail, { attempts: 3 });
+              mailQueue.add(tipoNotificacion, jobMail, { attempts: 3 });
 
               resolve({ status: 200 });
             });
@@ -125,7 +125,7 @@ notificationService.notificacionOportunidadEliminada = (job) => {
   });
 };
 
-notificationService.notificacionNuevaParticipacion = (participacion) => {
+const saveDbNotificacionNuevaParticipacion = function (participacion) {
   return new Promise((resolve, reject) => {
     const detalles = {
       rfp: participacion.rfpInvolucrado,
@@ -186,6 +186,59 @@ notificationService.notificacionNuevaParticipacion = (participacion) => {
             reject(error);
           });
       });
+  });
+};
+
+const mailNuevaParticipacion = function (participacion) {
+  return new Promise((resolve, reject) => {
+    const detalles = {
+      rfp: participacion.rfpInvolucrado,
+      participante: participacion.socioInvolucrado,
+    };
+    RfpModel.findById(detalles.rfp)
+      .then((rfp) => {
+        UserModel.findById(detalles.participante)
+          .then((participante) => {
+            const rfpMail = {
+              nombreOportunidad: rfp.nombreOportunidad,
+              participanteName: participante.name
+            };
+            mailService.buildMailContent(NUEVA_PARTICIPACION, rfpMail)
+              .then((mailContent) => {
+                UserModel.findById(rfp.createdBy)
+                  .then((cliente) => {
+                    const jobMail = {
+                      mailContent: mailContent,
+                      destinatario: {
+                        name: cliente.name,
+                        email: cliente.email
+                      }
+                    };
+                    mailQueue.add(NUEVA_PARTICIPACION, jobMail, { attempts: 3 });
+
+                    resolve({ status: 200 });
+                  })
+                  .catch((error) => reject(error));
+              })
+              .catch((error) => reject(error));
+          })
+          .catch((error) => reject(error));
+      })
+      .catch((error) => reject(error));
+  });
+};
+
+notificationService.notificacionNuevaParticipacion = (participacion) => {
+  return new Promise((resolve, reject) => {
+    saveDbNotificacionNuevaParticipacion(participacion)
+      .then((resp) => {
+        mailNuevaParticipacion(participacion)
+          .then((respMail) => {
+            resolve(respMail);
+          })
+          .catch((error) => reject(error));
+      })
+      .catch((error) => reject(error));
   });
 };
 


### PR DESCRIPTION
Este PR agrega la funcionalidad de enviar los mails de notificación de `NUEVA_PARTICIPACION` a un cliente cuando un socio aplica a su Oportunidad Comercial.

En `NotificationService` se cambió el nombre de la función `notificacionNuevaParticipacion` a `saveDbNotificacionNuevaParticipacion`, y en la función `notificacionNuevaParticipacion` se llama a `saveDbNotificacionNuevaParticipacion` seguido de `mailNuevaParticipacion`, con el fin de desacoplar las operaciones en la DB y las de enviar mails.

También agregla un bug en la función `mailTodosSocios`, donde se utilizaba el `tipoNotificacion` equivocado al agregar a la `mailQueue`.

**Potencial to-do:** Realizar las operaciones de extracción de datos de la DB una sola vez, en lugar de hacerlas una vez dentro de `saveDbNotificacionNuevaParticipacion` y una segunda vez en `mailNuevaParticipacion`.