### PR TITLE
Send notification mail for NUEVO_EVENTO

### DIFF
--- a/server/controllers/EventController.js
+++ b/server/controllers/EventController.js
@@ -1,140 +1,146 @@
 const Event = require("../models/Event");
 const User = require("../models/User");
 const Participacion = require("../models/Participaciones");
+const notificationService = require("../services/NotificationService");
 let eventController = {};
 
 eventController.getUserEvents = (userId) => {
-   return new Promise((resolve, reject) => {
-      User.findById(userId)
-         .then((user) => {
-            user
-               .retrieveEvents()
-               .then((events) => {
-                  resolve(events);
-               })
-               .catch((err) => {
-                  reject(err);
-               });
-         })
-         .catch((error) => {
-            reject(error);
-         });
-   });
+  return new Promise((resolve, reject) => {
+    User.findById(userId)
+      .then((user) => {
+        user
+          .retrieveEvents()
+          .then((events) => {
+            resolve(events);
+          })
+          .catch((err) => {
+            reject(err);
+          });
+      })
+      .catch((error) => {
+        reject(error);
+      });
+  });
 };
 
 eventController.createEvent = (rawEvent) => {
-   return new Promise((resolve, reject) => {
-      let newEvent = new Event(rawEvent);
-      newEvent
-         .save()
-         .then((event) => {
-            
-            resolve(newEvent);
-         })
-         .catch((err) => {
-            reject(err);
-         });
-   });
+  return new Promise((resolve, reject) => {
+    let newEvent = new Event(rawEvent);
+    newEvent
+      .save()
+      .then(() => {
+        return notificationService
+          .notificacionNuevoEvento(newEvent)
+          .then((resp) => {})
+          .catch((error) => reject(error));
+      })
+      .then((event) => {
+        resolve(newEvent);
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
 };
 
 eventController.assignToUsers = (opportunityId, eventId, evento, oppOwnerId) => {
-   return new Promise((resolve, reject) => {
-      let involvedUsersIds = [oppOwnerId];
-      Participacion.find({ rfpInvolucrado: opportunityId })
-         .then((participaciones) => {
-            participaciones.map((participacion) => {
-               involvedUsersIds.push(participacion.socioInvolucrado);
+  return new Promise((resolve, reject) => {
+    let involvedUsersIds = [oppOwnerId];
+    Participacion.find({ rfpInvolucrado: opportunityId })
+      .then((participaciones) => {
+        participaciones.map((participacion) => {
+          involvedUsersIds.push(participacion.socioInvolucrado);
+        });
+        User.find({ _id: { $in: involvedUsersIds } })
+          .then((involvedUsers) => {
+            let emailsList = [];
+            involvedUsers.map((involvedUser) => {
+              emailsList.push(involvedUser.email);
+              involvedUser.addEvent(eventId);
             });
-            User.find({ _id: { $in: involvedUsersIds } })
-               .then((involvedUsers) => {
-                  let emailsList = []
-                  involvedUsers.map((involvedUser) => {
-                     emailsList.push(involvedUser.email)
-                     involvedUser.addEvent(eventId);
-                  });
-                  resolve(involvedUsers);
-               })
-               .catch((err) => {
-                  console.log(err);
-                  reject(err);
-               });
-         })
-         .catch((err) => {
+            resolve(involvedUsers);
+          })
+          .catch((err) => {
+            console.log(err);
             reject(err);
-         });
-   });
+          });
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
 };
 
 eventController.deleteUserFromEvent = (userId, eventId) => {
-   return new Promise((resolve, reject) => {
-      User.update({ _id: userId }, { $pull: { events: eventId } })
-         .then((user) => {
-            resolve(user);
-         })
-         .catch((err) => {
-            reject(err);
-         });
-   });
+  return new Promise((resolve, reject) => {
+    User.update({ _id: userId }, { $pull: { events: eventId } })
+      .then((user) => {
+        resolve(user);
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
 };
 
 eventController.editEvent = (eventId, updates) => {
-   return new Promise((resolve, reject) => {
-      Event.findByIdAndUpdate(eventId, updates)
-      .then(eventUpdated => {
-         resolve(eventUpdated);
+  return new Promise((resolve, reject) => {
+    Event.findByIdAndUpdate(eventId, updates)
+      .then((eventUpdated) => {
+        resolve(eventUpdated);
       })
-      .catch(err => {
-         reject(err);
-      })
-   })
-}
+      .catch((err) => {
+        reject(err);
+      });
+  });
+};
 
 eventController.deleteEvent = (eventId) => {
-   return new Promise((resolve, reject) => {
-      Event.findByIdAndDelete(eventId)
-      .then(deletedEvent => {
-         resolve(deletedEvent);
+  return new Promise((resolve, reject) => {
+    Event.findByIdAndDelete(eventId)
+      .then((deletedEvent) => {
+        resolve(deletedEvent);
       })
-      .catch(err => {
-         reject(err);
-      })
-   })
-}
+      .catch((err) => {
+        reject(err);
+      });
+  });
+};
 
 eventController.getRFPEvents = (rfpId) => {
-   return new Promise((resolve, reject) => {
-      Event.find({ rfp: rfpId })
-         .then((events) => {
-            resolve(events);
-         })
-         .catch((err) => {
-            reject(err);
-         });
-   });
+  return new Promise((resolve, reject) => {
+    Event.find({ rfp: rfpId })
+      .then((events) => {
+        resolve(events);
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
 };
 
 eventController.addUserToEvent = (userId, eventId) => {
-   return new Promise((resolve, reject) => {
-      User.update({ _id: userId }, { $push: { events: eventId } })
-         .then((update) => {
-            resolve(update);
-         })
-         .catch((err) => {
-            reject(err);
-         });
-   });
+  return new Promise((resolve, reject) => {
+    User.update({ _id: userId }, { $push: { events: eventId } })
+      .then((update) => {
+        resolve(update);
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
 };
 
 eventController.getAllEvents = () => {
-   return new Promise((resolve, reject) => {
-      Event.find({})
-      .then(events => {
-         resolve(events);
+  return new Promise((resolve, reject) => {
+    Event.find({})
+      .then((events) => {
+        resolve(events);
       })
-      .catch(err => {
-         reject(err);
-      })
-   })
-}
+      .catch((err) => {
+        reject(err);
+      });
+  });
+};
 
 module.exports = eventController;

--- a/server/models/RFP.js
+++ b/server/models/RFP.js
@@ -95,6 +95,19 @@ schema.statics.getCreatedBy = function (rfpId) {
   });
 };
 
+schema.statics.getNombreOportunidad = function (rfpId) {
+  return new Promise((resolve, reject) => {
+    this.findById( rfpId )
+      .then((rfp) => {
+        const nombreOportunidad = rfp.nombreOportunidad;
+        resolve(nombreOportunidad);
+      })
+      .catch((error) => {
+        reject(error);
+      });
+  });
+};
+
 const miRFP = mongoose.model("RFP", schema);
 
 module.exports = miRFP;

--- a/server/services/MailQueue.js
+++ b/server/services/MailQueue.js
@@ -1,6 +1,6 @@
 const Queue = require("bull");
 const redisConfig = require("../config/redisConfig");
-const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION } = require("../utils/NotificationTypes");
+const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION, NUEVO_EVENTO } = require("../utils/NotificationTypes");
 const mailService = require("./MailService");
 
 const mailQueue = new Queue("mail-queue", { redisConfig });
@@ -10,6 +10,10 @@ mailQueue.process(NUEVA_OPORTUNIDAD, (job) => {
 });
 
 mailQueue.process(NUEVA_PARTICIPACION, (job) => {
+  return mailService.sendEmail(job.data);
+});
+
+mailQueue.process(NUEVO_EVENTO, (job) => {
   return mailService.sendEmail(job.data);
 });
 

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -107,19 +107,19 @@ mailService.buildMailContent = (tipoNotificacion, rfp) => {
         break;
 
       case NUEVO_EVENTO:
-        const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-        const eventDate = `${moment.utc(rfp.date).toDate().toLocaleDateString('es-ES', dateOptions)} ${moment.utc(rfp.date).toDate().toLocaleTimeString('en-US')}`
+        moment.locale("es-us")
+        const eventDate = upperCaseFirstLetter(moment(rfp.date).format("LLLL"));
 
         mailOptions.subject = "Nueva junta para Oportunidad Comercial";
         mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${rfp.nombreOportunidad}" en la cual estás participando:
         Nombre: ${rfp.name}
         Fecha: ${eventDate}
-        Liga de la reunion: ${rfp.link}`;
+        Liga de la reunión: ${rfp.link}`;
 
         mailOptions.html = `se ha agendado una nueva junta para la Oportunidad Comercial "${rfp.nombreOportunidad}" en la cual estás participando:</p>
         <p><b>Nombre:</b> ${rfp.name}<br>
         <b>Fecha:</b> ${eventDate}<br>
-        <b>Liga de la reunion:</b> <a href="${rfp.link}">${rfp.link}</a></p>`;
+        <b>Liga de la reunión:</b> <a href="${rfp.link}">${rfp.link}</a></p>`;
         break;
 
       default:
@@ -184,5 +184,9 @@ const generatePdf = (bodyTitle, htmlBody) => {
     });
   });
 };
+
+const upperCaseFirstLetter = (string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
 
 module.exports = mailService;

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -1,7 +1,11 @@
 const nodemailer = require("nodemailer");
 const moment = require("moment");
-const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION, NUEVO_EVENTO } = require("../utils/NotificationTypes");
 var pdf = require("html-pdf");
+const {
+  NUEVA_OPORTUNIDAD,
+  NUEVA_PARTICIPACION,
+  NUEVO_EVENTO
+} = require("../utils/NotificationTypes");
 
 var options = { format: "Letter" };
 const mailService = {};
@@ -11,12 +15,12 @@ var mailConfig = {
   pool: true,
   auth: {
     user: process.env.MAIL_USER,
-    pass: process.env.MAIL_PASSWORD,
+    pass: process.env.MAIL_PASSWORD
   },
 };
 
 var transporter = nodemailer.createTransport(mailConfig, {
-  from: `Oportunidades Comerciales CSOFTMTY <${process.env.MAIL_USER}>`,
+  from: `Oportunidades Comerciales CSOFTMTY <${process.env.MAIL_USER}>`
 });
 
 // email sender function
@@ -28,15 +32,15 @@ mailService.sendEmail = (jobData) => {
       to: destinatario.email,
       subject: mailContent.subject,
       text: `Hola ${destinatario.name}, ${mailContent.text}`,
-      html: `<p>Hola ${destinatario.name}, ${mailContent.html}`,
+      html: `<p>Hola ${destinatario.name}, ${mailContent.html}`
     };
 
     if (mailContent.attachments) {
       mailOptions.attachments = {
         filename: mailContent.attachments.filename,
         content: mailContent.attachments.content,
-        encoding: 'base64',
-      }
+        encoding: "base64"
+      };
     }
 
     transporter.sendMail(mailOptions, (err, info) => {
@@ -74,122 +78,106 @@ mailService.buildMailContent = (tipoNotificacion, rfp) => {
 
         Datos de contacto
         Nombre: ${rfp.nombrecliente}
-        Posición: ${rfp.posicioncliente}
+        Posición: ${rfp.posicioncliente}`;
 
-        Gracias,
-        Notificaciones de CSOFTMTY`;
-
-        mailOptions.html = `
-        <!doctype html>
-        <html>
-          <head>
-            <style>
-            h1{
-              margin-top:40px;
-              text-align:center;
-              font-family:Helvetica;
-            }
-            h3{
-              font-weight:bold;
-              font-family:Helvetica;
-            }
-            p{
-              font-family:Helvetica;
-            }
-            b{
-              font-family:Helvetica;
-            }
-            img{
-              display:block;
-              margin-left:auto;
-              margin-right:auto;
-              width:50%;
-            }
-            body{
-              margin:50px;
-            }
-            </style>
-          </head>
-            <h1>Nueva Oportunidad Comercial</h1>
-            <body>
-              <div>
-                <h3>Datos generales</h3>
-                <p><b>Nombre de la Oportunidad Comercial:</b> ${rfp.nombreOportunidad}<br>
-                <b>Objetivo de la oportunidad:</b> ${rfp.objetivoOportunidad}<br>
-                <b>Descripción funcional de la oportunidad:</b> ${rfp.descripcionFuncional}<br>
-              </div>
-              <div>
-                <h3>Detalle de la oportunidad</h3>
-                <b>Requerimientos obligatorios:</b> ${rfp.requerimientosObligatorios}<br>
-                <b>Fechas relevantes:</b> ${rfp.fechasRelevantes}<br><br>
-              </div>
-              <div>
-                <h3>Estatus de la necesidad</h3>
-                <b>¿Ha sido aprobada por el área usuaria?:</b> ${rfp.aprobadaAreaUsuario}<br>
-                <b>¿Ha sido aprobada por el área de TI?:</b> ${rfp.aprobadaAreaTI}<br>
-                <b>¿Tiene un presupuesto asignado?:</b> ${rfp.presupuestoAsignado}<br>
-                <b>Tipo general del proyecto:</b> ${rfp.tipoGeneralProyecto}<br>
-                <b>Tipo específico del proyecto:</b> ${rfp.tipoEspecificoProyecto}<br>
-                <b>Comentarios adicionales:</b> ${rfp.comentariosAdicionales}</p>
-              </div>
-              <div>
-                <h3>Datos de contacto</h3>
-                <p><b>Nombre:</b> ${rfp.nombrecliente}<br>
-                <b>Posición:</b> ${rfp.posicioncliente}<br>
-              </div>
-              <br>
-            </body>
-        </html>`;
+        mailOptions.html = `<h3>Datos generales</h3>
+        <p><b>Nombre de la Oportunidad Comercial:</b> ${rfp.nombreOportunidad}<br>
+        <b>Objetivo de la oportunidad:</b> ${rfp.objetivoOportunidad}<br>
+        <b>Descripción funcional de la oportunidad:</b> ${rfp.descripcionFuncional}</p>
+        <h3>Detalle de la oportunidad</h3>
+        <p><b>Requerimientos obligatorios:</b> ${rfp.requerimientosObligatorios}<br>
+        <b>Fechas relevantes:</b> ${rfp.fechasRelevantes}</p>
+        <h3>Estatus de la necesidad</h3>
+        <p><b>¿Ha sido aprobada por el área usuaria?:</b> ${rfp.aprobadaAreaUsuario}<br>
+        <b>¿Ha sido aprobada por el área de TI?:</b> ${rfp.aprobadaAreaTI}<br>
+        <b>¿Tiene un presupuesto asignado?:</b> ${rfp.presupuestoAsignado}<br>
+        <b>Tipo general del proyecto:</b> ${rfp.tipoGeneralProyecto}<br>
+        <b>Tipo específico del proyecto:</b> ${rfp.tipoEspecificoProyecto}<br>
+        <b>Comentarios adicionales:</b> ${rfp.comentariosAdicionales}</p>
+        <h3>Datos de contacto</h3>
+        <p><b>Nombre:</b> ${rfp.nombrecliente}<br>
+        <b>Posición:</b> ${rfp.posicioncliente}</p>
+        <br>`;
         break;
 
       case NUEVA_PARTICIPACION:
         mailOptions.subject = "Un socio de CSOFTMTY ha aplicado a tu Oportunidad Comercial";
-        mailOptions.text = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".`
-
-        mailOptions.html = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".</p>`
+        mailOptions.text = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".`;
+        mailOptions.html = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".</p>`;
         break;
 
       case NUEVO_EVENTO:
         const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
         const eventDate = `${moment.utc(rfp.date).toDate().toLocaleDateString('es-ES', dateOptions)} ${moment.utc(rfp.date).toDate().toLocaleTimeString('en-US')}`
+
         mailOptions.subject = "Nueva junta para Oportunidad Comercial";
         mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${rfp.nombreOportunidad}" en la cual estás participando:
         Nombre: ${rfp.name}
         Fecha: ${eventDate}
-        Liga de la reunion: ${rfp.link}`
+        Liga de la reunion: ${rfp.link}`;
 
         mailOptions.html = `se ha agendado una nueva junta para la Oportunidad Comercial "${rfp.nombreOportunidad}" en la cual estás participando:</p>
         <p><b>Nombre:</b> ${rfp.name}<br>
         <b>Fecha:</b> ${eventDate}<br>
-        <b>Liga de la reunion:</b> <a href="${rfp.link}">${rfp.link}</a></p>`
+        <b>Liga de la reunion:</b> <a href="${rfp.link}">${rfp.link}</a></p>`;
         break;
 
       default:
         reject("Invalid notificationType");
     }
 
+    mailOptions.text += "\n\nGracias,\nNotificaciones de CSOFTMTY";
+    mailOptions.html += `<p>Gracias,<br>
+    Notificaciones de CSOFTMTY</p>
+    <img src="https://www.csoftmty.org/assets/images/header/logo.png" alt="logo_csoftmty"/>`;
+
     if (tipoNotificacion === NUEVA_OPORTUNIDAD) {
-      generatePdf(mailOptions.html).then((base64String) => {
+      generatePdf("Nueva Oportunidad Comercial", mailOptions.html).then((base64String) => {
         mailOptions.attachments = {
           filename: `${rfp.nombreOportunidad}.pdf`,
           content: base64String,
         };
+        mailOptions.html = "te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:" + mailOptions.html;
         resolve(mailOptions);
       });
-    }
-    else {
-      mailOptions.text += "\n\nGracias,\nNotificaciones de CSOFTMTY";
-      mailOptions.html += `<p>Gracias,<br>
-        Notificaciones de CSOFTMTY</p>
-        <img src="https://www.csoftmty.org/assets/images/header/logo.png" alt="logo_csoftmty"/>`
+    } else {
       resolve(mailOptions);
     }
-    
   });
 };
 
-const generatePdf = (htmlToPdf) => {
+const generatePdf = (bodyTitle, htmlBody) => {
   return new Promise((resolve, reject) => {
+    htmlToPdf = `
+    <!doctype html>
+    <html>
+      <head>
+        <style>
+        h1 {
+          margin-top:40px;
+          text-align:center;
+        }
+        h3 {
+          font-weight:bold;
+        }
+        img {
+          display:block;
+          margin-left:auto;
+          margin-right:auto;
+          width:50%;
+        }
+        body {
+          font-family:Helvetica;
+          margin:50px;
+        }
+        </style>
+      </head>
+        <body>
+          <h1>${bodyTitle}</h1>
+          ${htmlBody}
+        </body>
+    </html>`;
+
     pdf.create(htmlToPdf, options).toBuffer(function (err, res) {
       if (err) reject(err);
       resolve(res.toString("base64"));

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -29,13 +29,15 @@ mailService.sendEmail = (jobData) => {
       subject: mailContent.subject,
       text: `Hola ${destinatario.name}, ${mailContent.text}`,
       html: `<p>Hola ${destinatario.name}, ${mailContent.html}`,
-      attachments: {
+    };
+
+    if (mailContent.attachments) {
+      mailOptions.attachments = {
         filename: mailContent.attachments.filename,
         content: mailContent.attachments.content,
         encoding: 'base64',
       }
-    };
-
+    }
 
     transporter.sendMail(mailOptions, (err, info) => {
       if (err) {
@@ -74,75 +76,72 @@ mailService.buildMailContent = (tipoNotificacion, rfp) => {
         Nombre: ${rfp.nombrecliente}
         Posición: ${rfp.posicioncliente}
 
-
-
         Gracias,
         Notificaciones de CSOFTMTY`;
 
         mailOptions.html = `
         <!doctype html>
-          <html>
-            <head>
-              <style>
-              h1{
-                margin-top:40px;
-                text-align:center;
-                font-family:Helvetica;
-              }
-              h3{
-                font-weight:bold;
-                font-family:Helvetica;
-              }
-              p{
-                font-family:Helvetica;
-              }
-              b{
-                font-family:Helvetica;
-              }
-              img{
-                display:block;
-                margin-left:auto;
-                margin-right:auto;
-                width:50%;
-              }
-              body{
-                margin:50px;
-              }
-              </style>
-            </head>
-              <h1>Nueva Oportunidad Comercial</h1>
-                <body>
-                  <div>
-                    <h3>Datos generales</h3>
-                    <p><b>Nombre de la Oportunidad Comercial:</b> ${rfp.nombreOportunidad}<br>
-                    <b>Objetivo de la oportunidad:</b> ${rfp.objetivoOportunidad}<br>
-                    <b>Descripción funcional de la oportunidad:</b> ${rfp.descripcionFuncional}<br>
-                  </div>
-                    <div>
-                      <h3>Detalle de la oportunidad</h3>
-                      <b>Requerimientos obligatorios:</b> ${rfp.requerimientosObligatorios}<br>
-                      <b>Fechas relevantes:</b> ${rfp.fechasRelevantes}<br><br>
-                    </div>
-                      <div>
-                        <h3>Estatus de la necesidad</h3>
-                        <b>¿Ha sido aprobada por el área usuaria?:</b> ${rfp.aprobadaAreaUsuario}<br>
-                        <b>¿Ha sido aprobada por el área de TI?:</b> ${rfp.aprobadaAreaTI}<br>
-                        <b>¿Tiene un presupuesto asignado?:</b> ${rfp.presupuestoAsignado}<br>
-                        <b>Tipo general del proyecto:</b> ${rfp.tipoGeneralProyecto}<br>
-                        <b>Tipo específico del proyecto:</b> ${rfp.tipoEspecificoProyecto}<br>
-                        <b>Comentarios adicionales:</b> ${rfp.comentariosAdicionales}</p>
-                      </div>
-                        <div>
-                          <h3>Datos de contacto</h3>
-                          <p><b>Nombre:</b> ${rfp.nombrecliente}<br>
-                          <b>Posición:</b> ${rfp.posicioncliente}<br>
-                        </div>
-                          <br>
-                 </body>
-          </html>`;
+        <html>
+          <head>
+            <style>
+            h1{
+              margin-top:40px;
+              text-align:center;
+              font-family:Helvetica;
+            }
+            h3{
+              font-weight:bold;
+              font-family:Helvetica;
+            }
+            p{
+              font-family:Helvetica;
+            }
+            b{
+              font-family:Helvetica;
+            }
+            img{
+              display:block;
+              margin-left:auto;
+              margin-right:auto;
+              width:50%;
+            }
+            body{
+              margin:50px;
+            }
+            </style>
+          </head>
+            <h1>Nueva Oportunidad Comercial</h1>
+            <body>
+              <div>
+                <h3>Datos generales</h3>
+                <p><b>Nombre de la Oportunidad Comercial:</b> ${rfp.nombreOportunidad}<br>
+                <b>Objetivo de la oportunidad:</b> ${rfp.objetivoOportunidad}<br>
+                <b>Descripción funcional de la oportunidad:</b> ${rfp.descripcionFuncional}<br>
+              </div>
+              <div>
+                <h3>Detalle de la oportunidad</h3>
+                <b>Requerimientos obligatorios:</b> ${rfp.requerimientosObligatorios}<br>
+                <b>Fechas relevantes:</b> ${rfp.fechasRelevantes}<br><br>
+              </div>
+              <div>
+                <h3>Estatus de la necesidad</h3>
+                <b>¿Ha sido aprobada por el área usuaria?:</b> ${rfp.aprobadaAreaUsuario}<br>
+                <b>¿Ha sido aprobada por el área de TI?:</b> ${rfp.aprobadaAreaTI}<br>
+                <b>¿Tiene un presupuesto asignado?:</b> ${rfp.presupuestoAsignado}<br>
+                <b>Tipo general del proyecto:</b> ${rfp.tipoGeneralProyecto}<br>
+                <b>Tipo específico del proyecto:</b> ${rfp.tipoEspecificoProyecto}<br>
+                <b>Comentarios adicionales:</b> ${rfp.comentariosAdicionales}</p>
+              </div>
+              <div>
+                <h3>Datos de contacto</h3>
+                <p><b>Nombre:</b> ${rfp.nombrecliente}<br>
+                <b>Posición:</b> ${rfp.posicioncliente}<br>
+              </div>
+              <br>
+            </body>
+        </html>`;
         break;
 
-      
       case NUEVA_PARTICIPACION:
         mailOptions.subject = "Un socio de CSOFTMTY ha aplicado a tu Oportunidad Comercial";
         mailOptions.text = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".`
@@ -169,18 +168,23 @@ mailService.buildMailContent = (tipoNotificacion, rfp) => {
         reject("Invalid notificationType");
     }
 
-    mailOptions.text += "\n\nGracias,\nNotificaciones de CSOFTMTY";
-    mailOptions.html += `<p>Gracias,<br>
-      Notificaciones de CSOFTMTY</p>
-      <img src="https://www.csoftmty.org/assets/images/header/logo.png" alt="logo_csoftmty"/>`
-    
-    generatePdf(mailOptions.html).then((base64String) => {
-      mailOptions.attachments = {
-        filename: `${rfp.nombreOportunidad}.pdf`,
-        content: base64String,
-      };
+    if (tipoNotificacion === NUEVA_OPORTUNIDAD) {
+      generatePdf(mailOptions.html).then((base64String) => {
+        mailOptions.attachments = {
+          filename: `${rfp.nombreOportunidad}.pdf`,
+          content: base64String,
+        };
+        resolve(mailOptions);
+      });
+    }
+    else {
+      mailOptions.text += "\n\nGracias,\nNotificaciones de CSOFTMTY";
+      mailOptions.html += `<p>Gracias,<br>
+        Notificaciones de CSOFTMTY</p>
+        <img src="https://www.csoftmty.org/assets/images/header/logo.png" alt="logo_csoftmty"/>`
       resolve(mailOptions);
-    });
+    }
+    
   });
 };
 
@@ -192,4 +196,5 @@ const generatePdf = (htmlToPdf) => {
     });
   });
 };
+
 module.exports = mailService;

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -1,6 +1,8 @@
 const nodemailer = require("nodemailer");
-const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION } = require("../utils/NotificationTypes");
+const moment = require("moment");
+const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION, NUEVO_EVENTO } = require("../utils/NotificationTypes");
 var pdf = require("html-pdf");
+
 var options = { format: "Letter" };
 const mailService = {};
 
@@ -26,12 +28,12 @@ mailService.sendEmail = (jobData) => {
       to: destinatario.email,
       subject: mailContent.subject,
       text: `Hola ${destinatario.name}, ${mailContent.text}`,
-      html: `<p>Hola ${destinatario.name},${mailContent.html}`,
+      html: `<p>Hola ${destinatario.name}, ${mailContent.html}`,
       attachments: {
         filename: mailContent.attachments.filename,
         content: mailContent.attachments.content,
         encoding: 'base64',
-      },
+      }
     };
 
 
@@ -147,6 +149,22 @@ mailService.buildMailContent = (tipoNotificacion, rfp) => {
 
         mailOptions.html = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".</p>`
         break;
+
+      case NUEVO_EVENTO:
+        const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+        const eventDate = `${moment.utc(rfp.date).toDate().toLocaleDateString('es-ES', dateOptions)} ${moment.utc(rfp.date).toDate().toLocaleTimeString('en-US')}`
+        mailOptions.subject = "Nueva junta para Oportunidad Comercial";
+        mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${rfp.nombreOportunidad}" en la cual estás participando:
+        Nombre: ${rfp.name}
+        Fecha: ${eventDate}
+        Liga de la reunion: ${rfp.link}`
+
+        mailOptions.html = `se ha agendado una nueva junta para la Oportunidad Comercial "${rfp.nombreOportunidad}" en la cual estás participando:</p>
+        <p><b>Nombre:</b> ${rfp.name}<br>
+        <b>Fecha:</b> ${eventDate}<br>
+        <b>Liga de la reunion:</b> <a href="${rfp.link}">${rfp.link}</a></p>`
+        break;
+
       default:
         reject("Invalid notificationType");
     }

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -55,7 +55,7 @@ mailService.sendEmail = (jobData) => {
   });
 };
 
-mailService.buildMailContent = (tipoNotificacion, data) => {
+mailService.buildMailContent = (tipoNotificacion, mailData) => {
   return new Promise((resolve, reject) => {
     let mailOptions = {};
 
@@ -64,62 +64,62 @@ mailService.buildMailContent = (tipoNotificacion, data) => {
         mailOptions.subject = "Nueva Oportunidad Comercial";
         mailOptions.text = `te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:
 
-        Nombre de la Oportunidad Comercial: ${data.nombreOportunidad}
-        Objetivo de la oportunidad: ${data.objetivoOportunidad}
-        Descripción funcional de la oportunidad: ${data.descripcionFuncional}
-        Requerimientos obligatorios: ${data.requerimientosObligatorios}
-        Fechas relevantes: ${data.fechasRelevantes}
-        ¿Ha sido aprobada por el área usuaria?: ${data.aprobadaAreaUsuario}
-        ¿Ha sido aprobada por el área de TI?: ${data.aprobadaAreaTI}
-        ¿Tiene un presupuesto asignado?: ${data.presupuestoAsignado}
-        Tipo general del proyecto: ${data.tipoGeneralProyecto}
-        Tipo específico del proyecto: ${data.tipoEspecificoProyecto}
-        Comentarios adicionales: ${data.comentariosAdicionales}
+        Nombre de la Oportunidad Comercial: ${mailData.nombreOportunidad}
+        Objetivo de la oportunidad: ${mailData.objetivoOportunidad}
+        Descripción funcional de la oportunidad: ${mailData.descripcionFuncional}
+        Requerimientos obligatorios: ${mailData.requerimientosObligatorios}
+        Fechas relevantes: ${mailData.fechasRelevantes}
+        ¿Ha sido aprobada por el área usuaria?: ${mailData.aprobadaAreaUsuario}
+        ¿Ha sido aprobada por el área de TI?: ${mailData.aprobadaAreaTI}
+        ¿Tiene un presupuesto asignado?: ${mailData.presupuestoAsignado}
+        Tipo general del proyecto: ${mailData.tipoGeneralProyecto}
+        Tipo específico del proyecto: ${mailData.tipoEspecificoProyecto}
+        Comentarios adicionales: ${mailData.comentariosAdicionales}
 
         Datos de contacto
-        Nombre: ${data.nombrecliente}
-        Posición: ${data.posicioncliente}`;
+        Nombre: ${mailData.nombrecliente}
+        Posición: ${mailData.posicioncliente}`;
 
         mailOptions.html = `<h3>Datos generales</h3>
-        <p><b>Nombre de la Oportunidad Comercial:</b> ${data.nombreOportunidad}<br>
-        <b>Objetivo de la oportunidad:</b> ${data.objetivoOportunidad}<br>
-        <b>Descripción funcional de la oportunidad:</b> ${data.descripcionFuncional}</p>
+        <p><b>Nombre de la Oportunidad Comercial:</b> ${mailData.nombreOportunidad}<br>
+        <b>Objetivo de la oportunidad:</b> ${mailData.objetivoOportunidad}<br>
+        <b>Descripción funcional de la oportunidad:</b> ${mailData.descripcionFuncional}</p>
         <h3>Detalle de la oportunidad</h3>
-        <p><b>Requerimientos obligatorios:</b> ${data.requerimientosObligatorios}<br>
-        <b>Fechas relevantes:</b> ${data.fechasRelevantes}</p>
+        <p><b>Requerimientos obligatorios:</b> ${mailData.requerimientosObligatorios}<br>
+        <b>Fechas relevantes:</b> ${mailData.fechasRelevantes}</p>
         <h3>Estatus de la necesidad</h3>
-        <p><b>¿Ha sido aprobada por el área usuaria?:</b> ${data.aprobadaAreaUsuario}<br>
-        <b>¿Ha sido aprobada por el área de TI?:</b> ${data.aprobadaAreaTI}<br>
-        <b>¿Tiene un presupuesto asignado?:</b> ${data.presupuestoAsignado}<br>
-        <b>Tipo general del proyecto:</b> ${data.tipoGeneralProyecto}<br>
-        <b>Tipo específico del proyecto:</b> ${data.tipoEspecificoProyecto}<br>
-        <b>Comentarios adicionales:</b> ${data.comentariosAdicionales}</p>
+        <p><b>¿Ha sido aprobada por el área usuaria?:</b> ${mailData.aprobadaAreaUsuario}<br>
+        <b>¿Ha sido aprobada por el área de TI?:</b> ${mailData.aprobadaAreaTI}<br>
+        <b>¿Tiene un presupuesto asignado?:</b> ${mailData.presupuestoAsignado}<br>
+        <b>Tipo general del proyecto:</b> ${mailData.tipoGeneralProyecto}<br>
+        <b>Tipo específico del proyecto:</b> ${mailData.tipoEspecificoProyecto}<br>
+        <b>Comentarios adicionales:</b> ${mailData.comentariosAdicionales}</p>
         <h3>Datos de contacto</h3>
-        <p><b>Nombre:</b> ${data.nombrecliente}<br>
-        <b>Posición:</b> ${data.posicioncliente}</p>
+        <p><b>Nombre:</b> ${mailData.nombrecliente}<br>
+        <b>Posición:</b> ${mailData.posicioncliente}</p>
         <br>`;
         break;
 
       case NUEVA_PARTICIPACION:
         mailOptions.subject = "Un socio de CSOFTMTY ha aplicado a tu Oportunidad Comercial";
-        mailOptions.text = `queremos informarte que el socio ${data.participanteName} ha aplicado a tu Oportunidad Comercial "${data.nombreOportunidad}".`;
-        mailOptions.html = `queremos informarte que el socio ${data.participanteName} ha aplicado a tu Oportunidad Comercial "${data.nombreOportunidad}".</p>`;
+        mailOptions.text = `queremos informarte que el socio ${mailData.participanteName} ha aplicado a tu Oportunidad Comercial "${mailData.nombreOportunidad}".`;
+        mailOptions.html = `queremos informarte que el socio ${mailData.participanteName} ha aplicado a tu Oportunidad Comercial "${mailData.nombreOportunidad}".</p>`;
         break;
 
       case NUEVO_EVENTO:
         moment.locale("es-us");
-        const eventDate = upperCaseFirstLetter(moment(data.date).format("LLLL"));
+        const eventDate = upperCaseFirstLetter(moment(mailData.date).format("LLLL"));
 
         mailOptions.subject = "Nueva junta para Oportunidad Comercial";
-        mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${data.nombreOportunidad}" en la cual estás participando:
-        Nombre: ${data.name}
+        mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:
+        Nombre: ${mailData.name}
         Fecha: ${eventDate}
-        Liga de la reunión: ${data.link}`;
+        Liga de la reunión: ${mailData.link}`;
 
-        mailOptions.html = `se ha agendado una nueva junta para la Oportunidad Comercial "${data.nombreOportunidad}" en la cual estás participando:</p>
-        <p><b>Nombre:</b> ${data.name}<br>
+        mailOptions.html = `se ha agendado una nueva junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:</p>
+        <p><b>Nombre:</b> ${mailData.name}<br>
         <b>Fecha:</b> ${eventDate}<br>
-        <b>Liga de la reunión:</b> <a href="${data.link}">${data.link}</a></p>`;
+        <b>Liga de la reunión:</b> <a href="${mailData.link}">${mailData.link}</a></p>`;
         break;
 
       default:
@@ -134,7 +134,7 @@ mailService.buildMailContent = (tipoNotificacion, data) => {
     if (tipoNotificacion === NUEVA_OPORTUNIDAD) {
       generatePdf("Nueva Oportunidad Comercial", mailOptions.html).then((base64String) => {
         mailOptions.attachments = {
-          filename: `${data.nombreOportunidad}.pdf`,
+          filename: `${mailData.nombreOportunidad}.pdf`,
           content: base64String,
         };
         mailOptions.html = "te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:" + mailOptions.html;

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -55,7 +55,7 @@ mailService.sendEmail = (jobData) => {
   });
 };
 
-mailService.buildMailContent = (tipoNotificacion, rfp) => {
+mailService.buildMailContent = (tipoNotificacion, data) => {
   return new Promise((resolve, reject) => {
     let mailOptions = {};
 
@@ -64,62 +64,62 @@ mailService.buildMailContent = (tipoNotificacion, rfp) => {
         mailOptions.subject = "Nueva Oportunidad Comercial";
         mailOptions.text = `te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:
 
-        Nombre de la Oportunidad Comercial: ${rfp.nombreOportunidad}
-        Objetivo de la oportunidad: ${rfp.objetivoOportunidad}
-        Descripción funcional de la oportunidad: ${rfp.descripcionFuncional}
-        Requerimientos obligatorios: ${rfp.requerimientosObligatorios}
-        Fechas relevantes: ${rfp.fechasRelevantes}
-        ¿Ha sido aprobada por el área usuaria?: ${rfp.aprobadaAreaUsuario}
-        ¿Ha sido aprobada por el área de TI?: ${rfp.aprobadaAreaTI}
-        ¿Tiene un presupuesto asignado?: ${rfp.presupuestoAsignado}
-        Tipo general del proyecto: ${rfp.tipoGeneralProyecto}
-        Tipo específico del proyecto: ${rfp.tipoEspecificoProyecto}
-        Comentarios adicionales: ${rfp.comentariosAdicionales}
+        Nombre de la Oportunidad Comercial: ${data.nombreOportunidad}
+        Objetivo de la oportunidad: ${data.objetivoOportunidad}
+        Descripción funcional de la oportunidad: ${data.descripcionFuncional}
+        Requerimientos obligatorios: ${data.requerimientosObligatorios}
+        Fechas relevantes: ${data.fechasRelevantes}
+        ¿Ha sido aprobada por el área usuaria?: ${data.aprobadaAreaUsuario}
+        ¿Ha sido aprobada por el área de TI?: ${data.aprobadaAreaTI}
+        ¿Tiene un presupuesto asignado?: ${data.presupuestoAsignado}
+        Tipo general del proyecto: ${data.tipoGeneralProyecto}
+        Tipo específico del proyecto: ${data.tipoEspecificoProyecto}
+        Comentarios adicionales: ${data.comentariosAdicionales}
 
         Datos de contacto
-        Nombre: ${rfp.nombrecliente}
-        Posición: ${rfp.posicioncliente}`;
+        Nombre: ${data.nombrecliente}
+        Posición: ${data.posicioncliente}`;
 
         mailOptions.html = `<h3>Datos generales</h3>
-        <p><b>Nombre de la Oportunidad Comercial:</b> ${rfp.nombreOportunidad}<br>
-        <b>Objetivo de la oportunidad:</b> ${rfp.objetivoOportunidad}<br>
-        <b>Descripción funcional de la oportunidad:</b> ${rfp.descripcionFuncional}</p>
+        <p><b>Nombre de la Oportunidad Comercial:</b> ${data.nombreOportunidad}<br>
+        <b>Objetivo de la oportunidad:</b> ${data.objetivoOportunidad}<br>
+        <b>Descripción funcional de la oportunidad:</b> ${data.descripcionFuncional}</p>
         <h3>Detalle de la oportunidad</h3>
-        <p><b>Requerimientos obligatorios:</b> ${rfp.requerimientosObligatorios}<br>
-        <b>Fechas relevantes:</b> ${rfp.fechasRelevantes}</p>
+        <p><b>Requerimientos obligatorios:</b> ${data.requerimientosObligatorios}<br>
+        <b>Fechas relevantes:</b> ${data.fechasRelevantes}</p>
         <h3>Estatus de la necesidad</h3>
-        <p><b>¿Ha sido aprobada por el área usuaria?:</b> ${rfp.aprobadaAreaUsuario}<br>
-        <b>¿Ha sido aprobada por el área de TI?:</b> ${rfp.aprobadaAreaTI}<br>
-        <b>¿Tiene un presupuesto asignado?:</b> ${rfp.presupuestoAsignado}<br>
-        <b>Tipo general del proyecto:</b> ${rfp.tipoGeneralProyecto}<br>
-        <b>Tipo específico del proyecto:</b> ${rfp.tipoEspecificoProyecto}<br>
-        <b>Comentarios adicionales:</b> ${rfp.comentariosAdicionales}</p>
+        <p><b>¿Ha sido aprobada por el área usuaria?:</b> ${data.aprobadaAreaUsuario}<br>
+        <b>¿Ha sido aprobada por el área de TI?:</b> ${data.aprobadaAreaTI}<br>
+        <b>¿Tiene un presupuesto asignado?:</b> ${data.presupuestoAsignado}<br>
+        <b>Tipo general del proyecto:</b> ${data.tipoGeneralProyecto}<br>
+        <b>Tipo específico del proyecto:</b> ${data.tipoEspecificoProyecto}<br>
+        <b>Comentarios adicionales:</b> ${data.comentariosAdicionales}</p>
         <h3>Datos de contacto</h3>
-        <p><b>Nombre:</b> ${rfp.nombrecliente}<br>
-        <b>Posición:</b> ${rfp.posicioncliente}</p>
+        <p><b>Nombre:</b> ${data.nombrecliente}<br>
+        <b>Posición:</b> ${data.posicioncliente}</p>
         <br>`;
         break;
 
       case NUEVA_PARTICIPACION:
         mailOptions.subject = "Un socio de CSOFTMTY ha aplicado a tu Oportunidad Comercial";
-        mailOptions.text = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".`;
-        mailOptions.html = `queremos informarte que el socio ${rfp.participanteName} ha aplicado a tu Oportunidad Comercial "${rfp.nombreOportunidad}".</p>`;
+        mailOptions.text = `queremos informarte que el socio ${data.participanteName} ha aplicado a tu Oportunidad Comercial "${data.nombreOportunidad}".`;
+        mailOptions.html = `queremos informarte que el socio ${data.participanteName} ha aplicado a tu Oportunidad Comercial "${data.nombreOportunidad}".</p>`;
         break;
 
       case NUEVO_EVENTO:
-        moment.locale("es-us")
-        const eventDate = upperCaseFirstLetter(moment(rfp.date).format("LLLL"));
+        moment.locale("es-us");
+        const eventDate = upperCaseFirstLetter(moment(data.date).format("LLLL"));
 
         mailOptions.subject = "Nueva junta para Oportunidad Comercial";
-        mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${rfp.nombreOportunidad}" en la cual estás participando:
-        Nombre: ${rfp.name}
+        mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${data.nombreOportunidad}" en la cual estás participando:
+        Nombre: ${data.name}
         Fecha: ${eventDate}
-        Liga de la reunión: ${rfp.link}`;
+        Liga de la reunión: ${data.link}`;
 
-        mailOptions.html = `se ha agendado una nueva junta para la Oportunidad Comercial "${rfp.nombreOportunidad}" en la cual estás participando:</p>
-        <p><b>Nombre:</b> ${rfp.name}<br>
+        mailOptions.html = `se ha agendado una nueva junta para la Oportunidad Comercial "${data.nombreOportunidad}" en la cual estás participando:</p>
+        <p><b>Nombre:</b> ${data.name}<br>
         <b>Fecha:</b> ${eventDate}<br>
-        <b>Liga de la reunión:</b> <a href="${rfp.link}">${rfp.link}</a></p>`;
+        <b>Liga de la reunión:</b> <a href="${data.link}">${data.link}</a></p>`;
         break;
 
       default:
@@ -134,7 +134,7 @@ mailService.buildMailContent = (tipoNotificacion, rfp) => {
     if (tipoNotificacion === NUEVA_OPORTUNIDAD) {
       generatePdf("Nueva Oportunidad Comercial", mailOptions.html).then((base64String) => {
         mailOptions.attachments = {
-          filename: `${rfp.nombreOportunidad}.pdf`,
+          filename: `${data.nombreOportunidad}.pdf`,
           content: base64String,
         };
         mailOptions.html = "te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:" + mailOptions.html;
@@ -187,6 +187,6 @@ const generatePdf = (bodyTitle, htmlBody) => {
 
 const upperCaseFirstLetter = (string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);
-}
+};
 
 module.exports = mailService;

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -8,6 +8,7 @@ const {
   OPORTUNIDAD_ELIMINADA,
   NUEVA_PARTICIPACION,
   CAMBIO_ESTATUS,
+  NUEVO_EVENTO
 } = require("../utils/NotificationTypes");
 const participacionController = require("../controllers/ParticipacionController");
 const detallesNotifController = require("../controllers/DetallesNotificacionController");
@@ -323,6 +324,50 @@ notificationService.notificacionNuevaParticipacion = (participacion) => {
           })
           .catch((error) => reject(error));
         */
+      })
+      .catch((error) => reject(error));
+  });
+};
+
+const mailNuevoEvento = function (evento) {
+  return new Promise((resolve, reject) => {
+    RfpModel.findById(evento.rfp)
+      .then((rfp) => {
+        const eventData = {
+          name: evento.name,
+          date: evento.date,
+          link: evento.link,
+          nombreOportunidad: rfp.nombreOportunidad
+        }
+        mailService.buildMailContent(NUEVO_EVENTO, eventData)
+        .then((mailContent) => {
+          UserModel.findByUserType("socio")
+          .then((socios) => {
+            socios.map((socio) => {
+              const jobMail = {
+                mailContent: mailContent,
+                destinatario: {
+                  name: socio.name,
+                  email: socio.email,
+                },
+              };
+              mailQueue.add(NUEVO_EVENTO, jobMail, { attempts: 3 });
+              
+              resolve({ status: 200 });
+            });
+          })
+          .catch((error) => reject(error));
+        })
+      })
+      .catch((error) => reject(error));
+  });
+};
+
+notificationService.notificacionNuevoEvento = (evento) => {
+  return new Promise((resolve, reject) => {
+    mailNuevoEvento(evento)
+      .then((respMail) => {
+        resolve(respMail);
       })
       .catch((error) => reject(error));
   });

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -140,14 +140,15 @@ const notificacionUsuarios = function (tipoNotificacion, detalles, socios) {
 
 const mailTodosSocios = function (tipoNotificacion, rfp) {
   return new Promise((resolve, reject) => {
-    UserModel.findByUserTypes(["socio", "admin"]).then((users) => {
-      if (!users || users.length == 0) resolve({ success: 1 });
+    UserModel.findByUserTypes(["socio", "admin"])
+      .then((users) => {
+        if (!users || users.length == 0) resolve({ success: 1 });
 
-      mailUsuarios(tipoNotificacion, rfp, users)
-        .then((resp) => {
-          resolve(resp);
-        })
-        .catch((error) => reject(error));
+        mailUsuarios(tipoNotificacion, rfp, users)
+          .then((resp) => {
+            resolve(resp);
+          })
+          .catch((error) => reject(error));
       })
       .catch((error) => reject(error));
   });
@@ -162,9 +163,10 @@ const mailParticipantesRfp = function (tipoNotificacion, mailData, rfpId) {
         });
       })
       .then((idSociosParticipantes) => {
-        if (!idSociosParticipantes || idSociosParticipantes.length == 0) resolve({ success: 1 });
-        
-        UserModel.find({_id: idSociosParticipantes}, 'name email')
+        if (!idSociosParticipantes || idSociosParticipantes.length == 0)
+          resolve({ success: 1 });
+
+        UserModel.find({ _id: idSociosParticipantes }, "name email")
           .then((sociosParticipantes) => {
             mailUsuarios(tipoNotificacion, mailData, sociosParticipantes)
               .then((resp) => {
@@ -180,7 +182,8 @@ const mailParticipantesRfp = function (tipoNotificacion, mailData, rfpId) {
 
 const mailUsuarios = function (tipoNotificacion, mailData, usuarios) {
   return new Promise((resolve, reject) => {
-    mailService.buildMailContent(tipoNotificacion, mailData)
+    mailService
+      .buildMailContent(tipoNotificacion, mailData)
       .then((mailContent) => {
         usuarios.map((usuario) => {
           const jobMail = {
@@ -322,6 +325,16 @@ notificationService.notificacionNuevaParticipacion = (participacion) => {
   });
 };
 
+notificationService.notificacionNuevoEvento = (evento) => {
+  return new Promise((resolve, reject) => {
+    mailNuevoEvento(evento)
+      .then((respMail) => {
+        resolve(respMail);
+      })
+      .catch((error) => reject(error));
+  });
+};
+
 const mailNuevoEvento = function (evento) {
   return new Promise((resolve, reject) => {
     RfpModel.getNombreOportunidad(evento.rfp)
@@ -337,16 +350,6 @@ const mailNuevoEvento = function (evento) {
             resolve(resp);
           })
           .catch((error) => reject(error));
-      })
-      .catch((error) => reject(error));
-  });
-};
-
-notificationService.notificacionNuevoEvento = (evento) => {
-  return new Promise((resolve, reject) => {
-    mailNuevoEvento(evento)
-      .then((respMail) => {
-        resolve(respMail);
       })
       .catch((error) => reject(error));
   });

--- a/server/utils/NotificationTypes.js
+++ b/server/utils/NotificationTypes.js
@@ -4,5 +4,6 @@ notificationTypes.NUEVA_OPORTUNIDAD = "NUEVA_OPORTUNIDAD";
 notificationTypes.OPORTUNIDAD_ELIMINADA = "OPORTUNIDAD_ELIMINADA";
 notificationTypes.NUEVA_PARTICIPACION = "NUEVA_PARTICIPACION";
 notificationTypes.CAMBIO_ESTATUS = "CAMBIO_ESTATUS";
+notificationTypes.NUEVO_EVENTO = "NUEVO_EVENTO";
 
 module.exports = notificationTypes;


### PR DESCRIPTION
Esta PR agrega:
- La notificación por mail para cuando se crea un nuevo evento en un RFP
- El método `getNombreOportunidad` en el modelo de `RFP`
- Delegar la responsabilidad de generar el HTML del PDF a la función `generatePDF` de `mailService`
- Arreglar un bug para que solo se genere un pdf de attachment para los mails de `NUEVA_OPORTUNIDAD`
- Separar en `notificationService` las responsabilidades de enviar correos en varias funciones en vez de tener toda la lógica para cada tipo de notificación en una sola función. Ejemplo: `notificacionNuevoEvento` llama a `mailNuevoEvento`, este llama a `mailParticipantesRfp`, y este finalmente llama a `mailUsuarios`. De esta manera, `mailUsuarios` contiene la lógica utilizada para enviar cualquier mail de notificación y `mailParticipantesRfp` puede ser reutilizada para la lógica de todas las notificaciones que tengan a los participantes de un RFP como destinatarios.

**Nota:** Había pusheado mi commit a `dev-walkelabs` en lugar de a la branch, pero le hice `revert` y luego `cherry-pick` para pushearlo a esta branch, por eso aparece que hay cambios en `dev-walkelabs` pero ya fueron revertidos.

Así se ve el mail ya enviado:
![ss_mail_nuevo_evento](https://user-images.githubusercontent.com/23624317/115938534-a52df400-a460-11eb-9055-441fcb752481.png)