### PR TITLE
Notificación mail CAMBIO_EVENTO

### DIFF
--- a/server/controllers/EventController.js
+++ b/server/controllers/EventController.js
@@ -87,6 +87,11 @@ eventController.editEvent = (eventId, updates) => {
   return new Promise((resolve, reject) => {
     Event.findByIdAndUpdate(eventId, updates)
       .then((eventUpdated) => {
+        // eventUpdated contains the data of the event before the update operation was performed
+        notificationService.notificacionCambioEvento(eventUpdated)
+          .then((resp) => {})
+          .catch((err) => reject(err));
+        
         resolve(eventUpdated);
       })
       .catch((err) => {

--- a/server/services/MailQueue.js
+++ b/server/services/MailQueue.js
@@ -1,6 +1,12 @@
 const Queue = require("bull");
 const redisConfig = require("../config/redisConfig");
-const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION, NUEVO_EVENTO, CAMBIO_EVENTO, CAMBIO_ESTATUS } = require("../utils/NotificationTypes");
+const {
+  NUEVA_OPORTUNIDAD,
+  NUEVA_PARTICIPACION,
+  NUEVO_EVENTO,
+  CAMBIO_EVENTO,
+  CAMBIO_ESTATUS
+} = require("../utils/NotificationTypes");
 const mailService = require("./MailService");
 
 const mailQueue = new Queue("mail-queue", { redisConfig });
@@ -21,9 +27,9 @@ mailQueue.process(CAMBIO_EVENTO, (job) => {
   return mailService.sendEmail(job.data);
 });
 
-mailQueue.process(CAMBIO_ESTATUS, (job)=>{
+mailQueue.process(CAMBIO_ESTATUS, (job) => {
   return mailService.sendEmail(job.data);
-})
+});
 
 mailQueue.on("stalled", function (job) {
   console.log("stalled job, restarting it again!", job.queue.name, job.data);

--- a/server/services/MailQueue.js
+++ b/server/services/MailQueue.js
@@ -1,6 +1,6 @@
 const Queue = require("bull");
 const redisConfig = require("../config/redisConfig");
-const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION, NUEVO_EVENTO } = require("../utils/NotificationTypes");
+const { NUEVA_OPORTUNIDAD, NUEVA_PARTICIPACION, NUEVO_EVENTO, CAMBIO_EVENTO } = require("../utils/NotificationTypes");
 const mailService = require("./MailService");
 
 const mailQueue = new Queue("mail-queue", { redisConfig });
@@ -14,6 +14,10 @@ mailQueue.process(NUEVA_PARTICIPACION, (job) => {
 });
 
 mailQueue.process(NUEVO_EVENTO, (job) => {
+  return mailService.sendEmail(job.data);
+});
+
+mailQueue.process(CAMBIO_EVENTO, (job) => {
   return mailService.sendEmail(job.data);
 });
 

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -4,7 +4,8 @@ var pdf = require("html-pdf");
 const {
   NUEVA_OPORTUNIDAD,
   NUEVA_PARTICIPACION,
-  NUEVO_EVENTO
+  NUEVO_EVENTO,
+  CAMBIO_EVENTO
 } = require("../utils/NotificationTypes");
 
 var options = { format: "Letter" };
@@ -107,8 +108,7 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
         break;
 
       case NUEVO_EVENTO:
-        moment.locale("es-us");
-        const eventDate = upperCaseFirstLetter(moment(mailData.date).format("LLLL"));
+        const eventDate = dateToString(mailData.date);
 
         mailOptions.subject = "Nueva junta para Oportunidad Comercial";
         mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:
@@ -120,6 +120,35 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
         <p><b>Nombre:</b> ${mailData.name}<br>
         <b>Fecha:</b> ${eventDate}<br>
         <b>Liga de la reunión:</b> <a href="${mailData.link}">${mailData.link}</a></p>`;
+        break;
+
+      case CAMBIO_EVENTO:
+        const dateEventUpdated = dateToString(mailData.eventUpdated.date);
+        const dateEventBeforeUpdate =
+          mailData.eventUpdated.date === mailData.eventBeforeUpdate.date
+            ? dateEventUpdated
+            : dateToString(mailData.eventBeforeUpdate.date);
+
+        mailOptions.subject = "Cambio en junta para Oportunidad Comercial";
+        mailOptions.text = `se han hecho cambios en una junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:
+        Datos actualizados:
+        Nombre: ${mailData.eventUpdated.name}
+        Fecha: ${dateEventUpdated}
+        Liga de la reunión: ${mailData.eventUpdated.link}
+        Datos antiguos:
+        Nombre: ${mailData.eventBeforeUpdate.name}
+        Fecha: ${dateEventBeforeUpdate}
+        Liga de la reunión: ${mailData.eventBeforeUpdate.link}`;
+
+        mailOptions.html = `se han hecho cambios en una junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:</p>
+        <h3>Datos actualizados:</h3>
+        <p><b>Nombre:</b> ${mailData.eventUpdated.name}<br>
+        <b>Fecha:</b> ${dateEventUpdated}<br>
+        <b>Liga de la reunión:</b> <a href="${mailData.eventUpdated.link}">${mailData.eventUpdated.link}</a></p>
+        <h3>Datos antiguos:</h3>
+        <p><b>Nombre:</b> ${mailData.eventBeforeUpdate.name}<br>
+        <b>Fecha:</b> ${dateEventBeforeUpdate}<br>
+        <b>Liga de la reunión:</b> <a href="${mailData.eventBeforeUpdate.link}">${mailData.eventBeforeUpdate.link}</a></p>`;
         break;
 
       default:
@@ -184,6 +213,11 @@ const generatePdf = (bodyTitle, htmlBody) => {
     });
   });
 };
+
+const dateToString = (date) => {
+  moment.locale("es-us");
+  return upperCaseFirstLetter(moment(date).format("LLLL"));
+}
 
 const upperCaseFirstLetter = (string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -31,7 +31,7 @@ mailService.sendEmail = (jobData) => {
     const { mailContent, destinatario } = jobData;
 
     const mailOptions = {
-      to: "a00820257@itesm.mx", //destinatario.email,
+      to: destinatario.email,
       subject: mailContent.subject,
       text: `Hola ${destinatario.name}, ${mailContent.text}`,
       html: `<p>Hola ${destinatario.name}, ${mailContent.html}`

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -31,7 +31,7 @@ mailService.sendEmail = (jobData) => {
     const { mailContent, destinatario } = jobData;
 
     const mailOptions = {
-      to: destinatario.email,
+      to: "a00820257@itesm.mx", //destinatario.email,
       subject: mailContent.subject,
       text: `Hola ${destinatario.name}, ${mailContent.text}`,
       html: `<p>Hola ${destinatario.name}, ${mailContent.html}`
@@ -153,9 +153,9 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
         break;
 
       case CAMBIO_ESTATUS:
-        mailOptions.subject = 'Cambio de estatus en la Oportunidad Comercial';
-        mailOptions.text = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad ${mailData.nombreOportunidad} a ${mailData.estatus}.`;
-        mailOptions.html = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad ${mailData.nombreOportunidad} a ${mailData.estatus}.</p>`;
+        mailOptions.subject = "Cambio de estatus en la Oportunidad Comercial";
+        mailOptions.text = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" a ${mailData.estatus}.`;
+        mailOptions.html = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" a ${mailData.estatus}.</p>`;
         break;
 
       default:
@@ -224,7 +224,7 @@ const generatePdf = (bodyTitle, htmlBody) => {
 const dateToString = (date) => {
   moment.locale("es-us");
   return upperCaseFirstLetter(moment(date).format("LLLL"));
-}
+};
 
 const upperCaseFirstLetter = (string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -9,9 +9,9 @@ const {
   NUEVA_OPORTUNIDAD,
   OPORTUNIDAD_ELIMINADA,
   NUEVA_PARTICIPACION,
-  CAMBIO_ESTATUS,
   NUEVO_EVENTO,
-  CAMBIO_EVENTO
+  CAMBIO_EVENTO,
+  CAMBIO_ESTATUS
 } = require("../utils/NotificationTypes");
 const detallesNotifController = require("../controllers/DetallesNotificacionController");
 const notificacionController = require("../controllers/NotificacionController");
@@ -86,18 +86,18 @@ notificationService.notificacionCambioEstatusOportunidad = (job) => {
               .catch((error) => reject(error));
           })
           .catch((error) => reject(error));
-            const rfpData = {
-              nombreCliente:rfp.nombrecliente,
-              nombreOportunidad:rfp.nombreOportunidad,
-              estatus:rfp.estatus
-            };
-            mailParticipantesRfp(CAMBIO_ESTATUS,rfpData,rfpId)
-            .then((resp)=>{
-              resolve(resp);
-            })
-            .catch((error)=>reject(error))
-          
-        })
+
+        const rfpData = {
+          nombreCliente: rfp.nombrecliente,
+          nombreOportunidad: rfp.nombreOportunidad,
+          estatus: rfp.estatus,
+        };
+        mailParticipantesRfp(CAMBIO_ESTATUS, rfpData, rfpId)
+          .then((resp) => {
+            resolve(resp);
+          })
+          .catch((error) => reject(error));
+      })
       .catch((error) => reject(error));
   });
 };

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -1,5 +1,6 @@
 const UserModel = require("../models/User");
 const RfpModel = require("../models/RFP");
+const EventModel = require("../models/Event");
 const NotificacionModel = require("../models/Notificacion");
 const ParticipacionModel = require("../models/Participaciones");
 const UsuarioNotificacionModel = require("../models/UsuarioNotificacion");
@@ -9,7 +10,8 @@ const {
   OPORTUNIDAD_ELIMINADA,
   NUEVA_PARTICIPACION,
   CAMBIO_ESTATUS,
-  NUEVO_EVENTO
+  NUEVO_EVENTO,
+  CAMBIO_EVENTO
 } = require("../utils/NotificationTypes");
 const detallesNotifController = require("../controllers/DetallesNotificacionController");
 const notificacionController = require("../controllers/NotificacionController");
@@ -346,6 +348,39 @@ const mailNuevoEvento = function (evento) {
           nombreOportunidad: nombreOportunidad
         };
         mailParticipantesRfp(NUEVO_EVENTO, eventData, evento.rfp)
+          .then((resp) => {
+            resolve(resp);
+          })
+          .catch((error) => reject(error));
+      })
+      .catch((error) => reject(error));
+  });
+};
+
+notificationService.notificacionCambioEvento = (eventBeforeUpdate) => {
+  return new Promise((resolve, reject) => {
+    EventModel.findById(eventBeforeUpdate._id)
+      .then((eventUpdated) => {
+        mailCambioEvento(eventBeforeUpdate, eventUpdated)
+          .then((respMail) => {
+            resolve(respMail);
+          })
+          .catch((error) => reject(error));
+      })
+      .catch((error) => reject(error));
+  });
+};
+
+const mailCambioEvento = function (eventBeforeUpdate, eventUpdated) {
+  return new Promise((resolve, reject) => {
+    RfpModel.getNombreOportunidad(eventUpdated.rfp)
+      .then((nombreOportunidad) => {
+        const eventData = {
+          nombreOportunidad: nombreOportunidad,
+          eventBeforeUpdate: eventBeforeUpdate,
+          eventUpdated: eventUpdated
+        };
+        mailParticipantesRfp(CAMBIO_EVENTO, eventData, eventUpdated.rfp)
           .then((resp) => {
             resolve(resp);
           })

--- a/server/utils/NotificationTypes.js
+++ b/server/utils/NotificationTypes.js
@@ -3,8 +3,8 @@ const notificationTypes = {};
 notificationTypes.NUEVA_OPORTUNIDAD = "NUEVA_OPORTUNIDAD";
 notificationTypes.OPORTUNIDAD_ELIMINADA = "OPORTUNIDAD_ELIMINADA";
 notificationTypes.NUEVA_PARTICIPACION = "NUEVA_PARTICIPACION";
-notificationTypes.CAMBIO_ESTATUS = "CAMBIO_ESTATUS";
 notificationTypes.NUEVO_EVENTO = "NUEVO_EVENTO";
 notificationTypes.CAMBIO_EVENTO = "CAMBIO_EVENTO";
+notificationTypes.CAMBIO_ESTATUS = "CAMBIO_ESTATUS";
 
 module.exports = notificationTypes;

--- a/server/utils/NotificationTypes.js
+++ b/server/utils/NotificationTypes.js
@@ -5,5 +5,6 @@ notificationTypes.OPORTUNIDAD_ELIMINADA = "OPORTUNIDAD_ELIMINADA";
 notificationTypes.NUEVA_PARTICIPACION = "NUEVA_PARTICIPACION";
 notificationTypes.CAMBIO_ESTATUS = "CAMBIO_ESTATUS";
 notificationTypes.NUEVO_EVENTO = "NUEVO_EVENTO";
+notificationTypes.CAMBIO_EVENTO = "CAMBIO_EVENTO";
 
 module.exports = notificationTypes;


### PR DESCRIPTION
Esta PR agrega los mails de notificación de `CAMBIO_EVENTO`.
Los mails se envían a los socios particantes del RFP al que pertenece el evento modificado.