### PR TITLE
previous and new status now showing in email notif

### DIFF
--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -154,8 +154,8 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
 
       case CAMBIO_ESTATUS:
         mailOptions.subject = "Cambio de estatus en la Oportunidad Comercial";
-        mailOptions.text = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" a ${mailData.estatus}.`;
-        mailOptions.html = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" a ${mailData.estatus}.</p>`;
+        mailOptions.text = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" de "${mailData.estatusPrevio}" a "${mailData.estatusNuevo}".`;
+        mailOptions.html = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" de "${mailData.estatusPrevio}" a "${mailData.estatusNuevo}".</p>`;
         break;
 
       default:

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -98,7 +98,8 @@ notificationService.notificacionCambioEstatusOportunidad = (job) => {
         const rfpData = {
           nombreCliente: rfp.nombrecliente,
           nombreOportunidad: rfp.nombreOportunidad,
-          estatus: rfp.estatus,
+          estatusPrevio: estatusPrevio,
+          estatusNuevo: estatusNuevo
         };
         mailParticipantesRfp(CAMBIO_ESTATUS, rfpData, rfpId)
           .then((resp) => {


### PR DESCRIPTION
Se añade en el rfpData el estatus previo y el nuevo para mostrar en la notificación CAMBIO_ESTATUS de cual a cuál se realizó el cambio.
