### PR TITLE
Refactor notification service

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -164,11 +164,12 @@ schema.statics.findByEmail = function(email) {
 
 /**
  * Gets users by type
- * @param {String} userType 
+ * @param {String} userType
+ * @param {String} fields optional fields to return
  */
-schema.statics.findByUserType = function (userType) {
+schema.statics.findByUserType = function (userType, fields="") {
   return new Promise((resolve, reject) => {
-    this.find({ userType: { $eq: userType } })
+    this.find({ userType: { $eq: userType } }, fields)
       .then((socios) => resolve(socios))
       .catch((error) => reject(error));
   });
@@ -177,10 +178,11 @@ schema.statics.findByUserType = function (userType) {
 /**
  * Gets users in array of types
  * @param {Array} userTypes
+ * @param {String} fields optional fields to return
  */
- schema.statics.findByUserTypes = function (userTypes) {
+ schema.statics.findByUserTypes = function (userTypes, fields="") {
    return new Promise((resolve, reject) => {
-     this.find({ userType: { $in: userTypes } })
+     this.find({ userType: { $in: userTypes } }, fields)
        .then((users) => resolve(users))
        .catch((error) => reject(error));
    });
@@ -202,7 +204,7 @@ schema.statics.findClientByRFP = function (rfpInvolucrado){
 /**
  * Get Array of Users with the socios who are participating in an RFP
  * @param {ObjectId} rfpId
- * @param {String} fields User fields to be selected for query, default value is all
+ * @param {String} fields optional fields to return
  */
 schema.statics.findParticipantesByRfp = function (rfpId, fields="") {
    return new Promise((resolve, reject) => {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -199,6 +199,23 @@ schema.statics.findClientByRFP = function (rfpInvolucrado){
 };
 
 /**
+ *  Get the name of a user, given the userId
+ * @param {ObjectId} userId
+ */
+schema.statics.getName = function (userId) {
+   return new Promise((resolve, reject) => {
+     this.findById( userId )
+       .then((user) => {
+         const name = user.name;
+         resolve(name);
+       })
+       .catch((error) => {
+         reject(error);
+       });
+   });
+ };
+
+/**
  * Hash password before saving user
  */
 schema.pre("save", function (next) {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -7,105 +7,109 @@ const RFP = require("./RFP");
 const Participacion = require("./Participaciones");
 
 const schema = new mongoose.Schema(
-   {
-      name: {
-         type: String,
-         required: true,
+  {
+    name: {
+      type: String,
+      required: true,
+    },
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      validate(value) {
+        if (!validator.isEmail(value)) {
+          throw new Error("Email invalido");
+        }
       },
-      email: {
-         type: String,
-         required: true,
-         unique: true,
-         validate(value) {
-            if (!validator.isEmail(value)) {
-               throw new Error("Email invalido");
-            }
-         },
+    },
+    telefono: {
+      type: String,
+    },
+    empresa: {
+      type: String,
+    },
+    password: {
+      type: String,
+      required: true,
+      minlength: 8,
+      trim: true,
+    },
+    tokens: [
+      {
+        token: {
+          type: String,
+          required: true,
+        },
       },
-      telefono: {
-         type: String
+    ],
+    isAdmin: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+    userType: {
+      type: String,
+      required: true,
+      validate(value) {
+        const allowedValues = ["cliente", "socio", "admin"];
+        if (!allowedValues.includes(value)) {
+          throw new Error("Tipo de usuario no valido");
+        }
       },
-      empresa: {
-         type: String
+    },
+    events: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "Event",
       },
-      password: {
-         type: String,
-         required: true,
-         minlength: 8,
-         trim: true,
+    ],
+    notificaciones: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "UsuarioNotificacion",
       },
-      tokens: [
-         {
-            token: {
-               type: String,
-               required: true,
-            },
-         },
-      ],
-      isAdmin: {
-         type: Boolean,
-         required: true,
-         default: false,
-      },
-      userType: {
-         type: String,
-         required: true,
-         validate(value) {
-            const allowedValues = ["cliente", "socio", "admin"];
-            if (!allowedValues.includes(value)) {
-               throw new Error("Tipo de usuario no valido");
-            }
-         },
-      },
-      events: [{
-         type: mongoose.Schema.Types.ObjectId,
-         ref: "Event"
-      }],
-      notificaciones: [{
-         type: mongoose.Schema.Types.ObjectId,
-         ref: "UsuarioNotificacion"
-      }]
-   },
-   {
-      toObject: {
-         virtuals: true,
-      },
-      toJSON: {
-         virtuals: true,
-      },
-   }
+    ],
+  },
+  {
+    toObject: {
+      virtuals: true,
+    },
+    toJSON: {
+      virtuals: true,
+    },
+  }
 );
 
 /**
  * Generates token for login
  */
 schema.methods.generateToken = function () {
-   const user = this;
-   const token = jwt.sign(
-      { _id: user._id.toString(), email: user.email, isAdmin: user.isAdmin },
-      process.env.JWT_KEY,
-      {
-         expiresIn: "7 days",
-      }
-   );
-   user.tokens = user.tokens.concat({ token });
-   return new Promise((resolve, reject) => {
-      user
-         .save()
-         .then((user) => {
-            return resolve(token);
-         })
-         .catch((error) => {
-            return reject(error);
-         });
-   });
+  const user = this;
+  const token = jwt.sign(
+    { _id: user._id.toString(), email: user.email, isAdmin: user.isAdmin },
+    process.env.JWT_KEY,
+    {
+      expiresIn: "7 days",
+    }
+  );
+  user.tokens = user.tokens.concat({ token });
+  return new Promise((resolve, reject) => {
+    user
+      .save()
+      .then((user) => {
+        return resolve(token);
+      })
+      .catch((error) => {
+        return reject(error);
+      });
+  });
 };
 
-schema.methods.addEvent = function(eventId) {
-   const user = this
-   this.events.push(eventId);
-   user.save();
-}
+schema.methods.addEvent = function (eventId) {
+  const user = this;
+  this.events.push(eventId);
+  user.save();
+};
 
 schema.methods.addNotificacion = function (notificacionId) {
   const user = this;
@@ -114,60 +118,61 @@ schema.methods.addNotificacion = function (notificacionId) {
 };
 
 //TODO: add return to promise
-schema.methods.retrieveEvents = function() {
-   const user = this;
-   let userEvents = user.events;
-   return new Promise((resolve, reject) => {
-      Event.find({ '_id': { $in: userEvents } })
-      .then(events => {
-         resolve(events)
-      }).catch(err => {
-         reject(err)
+schema.methods.retrieveEvents = function () {
+  const user = this;
+  let userEvents = user.events;
+  return new Promise((resolve, reject) => {
+    Event.find({ _id: { $in: userEvents } })
+      .then((events) => {
+        resolve(events);
       })
-   })
-}
+      .catch((err) => {
+        reject(err);
+      });
+  });
+};
 
 /**
  * Gets user that matches email and validates password
- * @param {String} email 
- * @param {String} password 
+ * @param {String} email
+ * @param {String} password
  */
 schema.statics.findByCredentials = (email, password) => {
-   return new Promise(function (resolve, reject) {
-      User.findOne({ email }).then(function (user) {
-         if (!user) {
-            return reject("User does not exist");
-         }
-         bcrypt
-            .compare(password, user.password)
-            .then(function (match) {
-               if (match) {
-                  return resolve(user);
-               } else {
-                  return reject("Wrong password!");
-               }
-            })
-            .catch(function (error) {
-               return reject("Wrong password!");
-            });
-      });
-   });
+  return new Promise(function (resolve, reject) {
+    User.findOne({ email }).then(function (user) {
+      if (!user) {
+        return reject("User does not exist");
+      }
+      bcrypt
+        .compare(password, user.password)
+        .then(function (match) {
+          if (match) {
+            return resolve(user);
+          } else {
+            return reject("Wrong password!");
+          }
+        })
+        .catch(function (error) {
+          return reject("Wrong password!");
+        });
+    });
+  });
 };
 
 /**
  * Gets user by email only
- * @param {String} email 
+ * @param {String} email
  */
-schema.statics.findByEmail = function(email) {
-   return this.findOne({ email }).exec();
-}
+schema.statics.findByEmail = function (email) {
+  return this.findOne({ email }).exec();
+};
 
 /**
  * Gets users by type
  * @param {String} userType
  * @param {String} fields optional fields to return
  */
-schema.statics.findByUserType = function (userType, fields="") {
+schema.statics.findByUserType = function (userType, fields = "") {
   return new Promise((resolve, reject) => {
     this.find({ userType: { $eq: userType } }, fields)
       .then((socios) => resolve(socios))
@@ -180,25 +185,12 @@ schema.statics.findByUserType = function (userType, fields="") {
  * @param {Array} userTypes
  * @param {String} fields optional fields to return
  */
- schema.statics.findByUserTypes = function (userTypes, fields="") {
-   return new Promise((resolve, reject) => {
-     this.find({ userType: { $in: userTypes } }, fields)
-       .then((users) => resolve(users))
-       .catch((error) => reject(error));
-   });
- };
-
-/**
- *  Get client who posted RFP
- * @param {ObjectId} rfpInvolucrado
- */
-schema.statics.findClientByRFP = function (rfpInvolucrado){
-   return new Promise((resolve,reject)=>{
-      //sacar createdBy, y ese id sera el cliente a quien mandarle
-      RFP.find({createdBy:rfpInvolucrado.createdBy})
-      .then((cliente) => resolve (cliente))
-      .catch((error)=> reject (error));
-   });
+schema.statics.findByUserTypes = function (userTypes, fields = "") {
+  return new Promise((resolve, reject) => {
+    this.find({ userType: { $in: userTypes } }, fields)
+      .then((users) => resolve(users))
+      .catch((error) => reject(error));
+  });
 };
 
 /**
@@ -206,26 +198,26 @@ schema.statics.findClientByRFP = function (rfpInvolucrado){
  * @param {ObjectId} rfpId
  * @param {String} fields optional fields to return
  */
-schema.statics.findParticipantesByRfp = function (rfpId, fields="") {
-   return new Promise((resolve, reject) => {
-     Participacion.find({ rfpInvolucrado: rfpId })
-       .then((participaciones) => {
-         return participaciones.map((participacion) => {
-           return participacion.socioInvolucrado;
-         });
-       })
-       .then((idSociosParticipantes) => {
-         if (!idSociosParticipantes || idSociosParticipantes.length == 0)
-           return resolve([]);
- 
-         this.find({ _id: idSociosParticipantes }, fields)
-           .then((sociosParticipantes) => {
-             resolve(sociosParticipantes);
-           })
-           .catch((error) => reject(error));
-       })
-       .catch((error) => reject(error));
-   });
+schema.statics.findParticipantesByRfp = function (rfpId, fields = "") {
+  return new Promise((resolve, reject) => {
+    Participacion.find({ rfpInvolucrado: rfpId })
+      .then((participaciones) => {
+        return participaciones.map((participacion) => {
+          return participacion.socioInvolucrado;
+        });
+      })
+      .then((idSociosParticipantes) => {
+        if (!idSociosParticipantes || idSociosParticipantes.length == 0)
+          return resolve([]);
+
+        this.find({ _id: idSociosParticipantes }, fields)
+          .then((sociosParticipantes) => {
+            resolve(sociosParticipantes);
+          })
+          .catch((error) => reject(error));
+      })
+      .catch((error) => reject(error));
+  });
 };
 
 /**
@@ -233,38 +225,38 @@ schema.statics.findParticipantesByRfp = function (rfpId, fields="") {
  * @param {ObjectId} userId
  */
 schema.statics.getName = function (userId) {
-   return new Promise((resolve, reject) => {
-     this.findById( userId )
-       .then((user) => {
-         const name = user.name;
-         resolve(name);
-       })
-       .catch((error) => {
-         reject(error);
-       });
-   });
- };
+  return new Promise((resolve, reject) => {
+    this.findById(userId)
+      .then((user) => {
+        const name = user.name;
+        resolve(name);
+      })
+      .catch((error) => {
+        reject(error);
+      });
+  });
+};
 
 /**
  * Hash password before saving user
  */
 schema.pre("save", function (next) {
-   const user = this;
-   if (user.isModified("password")) {
-      bcrypt
-         .hash(user.password, 8)
-         .then(function (hash) {
-            user.password = hash;
-            next();
-         })
-         .catch(function (error) {
-            return next(error);
-         });
-   } else {
-      next();
-   }
+  const user = this;
+  if (user.isModified("password")) {
+    bcrypt
+      .hash(user.password, 8)
+      .then(function (hash) {
+        user.password = hash;
+        next();
+      })
+      .catch(function (error) {
+        return next(error);
+      });
+  } else {
+    next();
+  }
 });
 
-const User = mongoose.model('User', schema)
+const User = mongoose.model("User", schema);
 
-module.exports = User
+module.exports = User;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -4,6 +4,7 @@ const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 const Event = require("./Event");
 const RFP = require("./RFP");
+const Participacion = require("./Participaciones");
 
 const schema = new mongoose.Schema(
    {
@@ -195,6 +196,33 @@ schema.statics.findClientByRFP = function (rfpInvolucrado){
       RFP.find({createdBy:rfpInvolucrado.createdBy})
       .then((cliente) => resolve (cliente))
       .catch((error)=> reject (error));
+   });
+};
+
+/**
+ * Get Array of Users with the socios who are participating in an RFP
+ * @param {ObjectId} rfpId
+ * @param {String} fields User fields to be selected for query, default value is all
+ */
+schema.statics.findParticipantesByRfp = function (rfpId, fields="") {
+   return new Promise((resolve, reject) => {
+     Participacion.find({ rfpInvolucrado: rfpId })
+       .then((participaciones) => {
+         return participaciones.map((participacion) => {
+           return participacion.socioInvolucrado;
+         });
+       })
+       .then((idSociosParticipantes) => {
+         if (!idSociosParticipantes || idSociosParticipantes.length == 0)
+           return resolve([]);
+ 
+         this.find({ _id: idSociosParticipantes }, fields)
+           .then((sociosParticipantes) => {
+             resolve(sociosParticipantes);
+           })
+           .catch((error) => reject(error));
+       })
+       .catch((error) => reject(error));
    });
 };
 

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -2,7 +2,6 @@ const UserModel = require("../models/User");
 const RfpModel = require("../models/RFP");
 const EventModel = require("../models/Event");
 const NotificacionModel = require("../models/Notificacion");
-const ParticipacionModel = require("../models/Participaciones");
 const UsuarioNotificacionModel = require("../models/UsuarioNotificacion");
 const DetallesNotificacionModel = require("../models/DetallesNotificacion");
 const {
@@ -23,7 +22,7 @@ const notificationService = {};
 
 notificationService.notificacionNuevaOportunidad = (job) => {
   return new Promise((resolve, reject) => {
-    UserModel.findByUserTypes(["socio", "admin"])
+    UserModel.findByUserTypes(["socio", "admin"], "name email")
       .then((users) => {
         if (!users || users.length == 0) resolve({ success: 1 });
 
@@ -48,7 +47,7 @@ notificationService.notificacionNuevaOportunidad = (job) => {
 
 notificationService.notificacionOportunidadEliminada = (job) => {
   return new Promise((resolve, reject) => {
-    UserModel.findByUserType("socio")
+    UserModel.findByUserType("socio", "_id")
       .then((socios) => {
         if (!socios || socios.length == 0) resolve({ success: 1 });
 
@@ -263,7 +262,7 @@ const mailNuevoEvento = function (evento, sociosParticipantes) {
 
 notificationService.notificacionCambioEvento = (eventBeforeUpdate) => {
   return new Promise((resolve, reject) => {
-    EventModel.findById(eventBeforeUpdate._id)
+    EventModel.findById(eventBeforeUpdate._id).select("name date link")
       .then((eventUpdated) => {
         if (eventBeforeUpdate.name == eventUpdated.name &&
           eventBeforeUpdate.link == eventUpdated.link &&
@@ -324,6 +323,8 @@ notificationService.deleteNotificacionesRfp = (rfpId) => {
   return new Promise((resolve, reject) => {
     DetallesNotificacionModel.findDetallesNotificacionByRfpId(rfpId)
       .then((detallesNotificaciones) => {
+        console.log("detallesNotificaciones");
+        console.log(detallesNotificaciones);
         const detallesNotifIds = detallesNotificaciones.map((detalles) => {
           return detalles._id;
         });

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -30,7 +30,7 @@ notificationService.notificacionNuevaOportunidad = (job) => {
         .then((resp) => {
           resolve(resp);
           /*
-          mailTodosSocios(NUEVA_OPORTUNIDAD, job.rfp)
+          mailUsuarios(NUEVA_OPORTUNIDAD, job.rfp, users)
             .then((respMail) => {
               resolve(respMail);
             })
@@ -146,22 +146,6 @@ const notificacionUsuarios = function (tipoNotificacion, detalles, socios) {
       .catch((error) => {
         reject(error);
       });
-  });
-};
-
-const mailTodosSocios = function (tipoNotificacion, rfp) {
-  return new Promise((resolve, reject) => {
-    UserModel.findByUserTypes(["socio", "admin"])
-      .then((users) => {
-        if (!users || users.length == 0) resolve({ success: 1 });
-
-        mailUsuarios(tipoNotificacion, rfp, users)
-          .then((resp) => {
-            resolve(resp);
-          })
-          .catch((error) => reject(error));
-      })
-      .catch((error) => reject(error));
   });
 };
 

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -76,7 +76,7 @@ notificationService.notificacionCambioEstatusOportunidad = (job) => {
         if (estatusPrevio == estatusNuevo) {
           return resolve({ success: 1 });
         }
-        getParticipantesRfp(rfpId)
+        UserModel.findParticipantesByRfp(rfpId, "name email")
           .then((sociosParticipantes) => {
             const detalles = {
               rfp: rfpId,
@@ -228,7 +228,7 @@ notificationService.notificacionNuevaParticipacion = (participacion) => {
 
 notificationService.notificacionNuevoEvento = (evento) => {
   return new Promise((resolve, reject) => {
-    getParticipantesRfp(evento.rfp)
+    UserModel.findParticipantesByRfp(evento.rfp, "name email")
       .then((sociosParticipantes) => {
         // TODO: notificacionUsuarios()... goes here
         mailNuevoEvento(evento, sociosParticipantes)
@@ -271,7 +271,7 @@ notificationService.notificacionCambioEvento = (eventBeforeUpdate) => {
             return resolve({ success: 1 });
         }
 
-        getParticipantesRfp(eventBeforeUpdate.rfp)
+        UserModel.findParticipantesByRfp(eventBeforeUpdate.rfp, "name email")
           .then((sociosParticipantes) => {
             // TODO: notificacionUsuarios()... goes here
             mailCambioEvento(eventBeforeUpdate, eventUpdated, sociosParticipantes)
@@ -305,6 +305,7 @@ const mailCambioEvento = function (eventBeforeUpdate, eventUpdated, sociosPartic
   });
 };
 
+// get Cliente in an array, so it can be processed by map() in notificacionUsuarios() & mailUsuarios()
 const getClienteRfp = function (rfpId) {
   return new Promise((resolve, reject) => {
     RfpModel.getCreatedBy(rfpId)
@@ -312,29 +313,6 @@ const getClienteRfp = function (rfpId) {
         UserModel.find({ _id: userId }, "name email")
           .then((cliente) => {
             resolve(cliente);
-          })
-          .catch((error) => reject(error));
-      })
-      .catch((error) => reject(error));
-  });
-};
-
-const getParticipantesRfp = function (rfpId) {
-  return new Promise((resolve, reject) => {
-    ParticipacionModel.find({ rfpInvolucrado: rfpId })
-      .then((participaciones) => {
-        return participaciones.map((participacion) => {
-          return participacion.socioInvolucrado;
-        });
-      })
-      .then((idSociosParticipantes) => {
-        if (!idSociosParticipantes || idSociosParticipantes.length == 0)
-          return resolve([]);
-          // resolve({ success: 1 });
-
-        UserModel.find({ _id: idSociosParticipantes }, "name email")
-          .then((sociosParticipantes) => {
-            resolve(sociosParticipantes);
           })
           .catch((error) => reject(error));
       })

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -10,7 +10,7 @@ const {
   NUEVA_PARTICIPACION,
   NUEVO_EVENTO,
   CAMBIO_EVENTO,
-  CAMBIO_ESTATUS
+  CAMBIO_ESTATUS,
 } = require("../utils/NotificationTypes");
 const detallesNotifController = require("../controllers/DetallesNotificacionController");
 const notificacionController = require("../controllers/NotificacionController");
@@ -38,7 +38,7 @@ notificationService.notificacionNuevaOportunidad = (job) => {
               })
               .catch((error) => reject(error));
             */
-            })
+          })
           .catch((error) => reject(error));
       })
       .catch((error) => reject(error));
@@ -248,7 +248,7 @@ const mailNuevoEvento = function (evento, sociosParticipantes) {
           name: evento.name,
           date: evento.date,
           link: evento.link,
-          nombreOportunidad: nombreOportunidad
+          nombreOportunidad: nombreOportunidad,
         };
         mailUsuarios(NUEVO_EVENTO, eventData, sociosParticipantes)
           .then((resp) => {
@@ -262,12 +262,13 @@ const mailNuevoEvento = function (evento, sociosParticipantes) {
 
 notificationService.notificacionCambioEvento = (eventBeforeUpdate) => {
   return new Promise((resolve, reject) => {
-    EventModel.findById(eventBeforeUpdate._id).select("name date link")
+    EventModel.findById(eventBeforeUpdate._id)
+      .select("name date link")
       .then((eventUpdated) => {
         if (eventBeforeUpdate.name == eventUpdated.name &&
           eventBeforeUpdate.link == eventUpdated.link &&
           eventBeforeUpdate.date.getTime() == eventUpdated.date.getTime()) {
-            return resolve({ success: 1 });
+          return resolve({ success: 1 });
         }
 
         UserModel.findParticipantesByRfp(eventBeforeUpdate.rfp, "name email")
@@ -292,7 +293,7 @@ const mailCambioEvento = function (eventBeforeUpdate, eventUpdated, sociosPartic
         const eventData = {
           nombreOportunidad: nombreOportunidad,
           eventBeforeUpdate: eventBeforeUpdate,
-          eventUpdated: eventUpdated
+          eventUpdated: eventUpdated,
         };
         mailUsuarios(CAMBIO_EVENTO, eventData, sociosParticipantes)
           .then((resp) => {

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -213,39 +213,20 @@ const mailUsuarios = function (tipoNotificacion, mailData, usuarios) {
   });
 };
 
-const mailNuevaParticipacion = function (participacion) {
+const mailNuevaParticipacion = function (detallesParticipacion, cliente) {
   return new Promise((resolve, reject) => {
-    const detalles = {
-      rfp: participacion.rfpInvolucrado,
-      participante: participacion.socioInvolucrado,
-    };
-    RfpModel.findById(detalles.rfp)
-      .then((rfp) => {
-        UserModel.findById(detalles.participante)
-          .then((participante) => {
+    RfpModel.getNombreOportunidad(detallesParticipacion.rfp)
+      .then((nombreOportunidad) => {
+        UserModel.getName(detallesParticipacion.participante)
+          .then((participanteName) => {
             const rfpMail = {
-              nombreOportunidad: rfp.nombreOportunidad,
-              participanteName: participante.name,
+              nombreOportunidad: nombreOportunidad,
+              participanteName: participanteName,
             };
-            mailService
-              .buildMailContent(NUEVA_PARTICIPACION, rfpMail)
-              .then((mailContent) => {
-                UserModel.findById(rfp.createdBy)
-                  .then((cliente) => {
-                    const jobMail = {
-                      mailContent: mailContent,
-                      destinatario: {
-                        name: cliente.name,
-                        email: cliente.email,
-                      },
-                    };
-                    mailQueue.add(NUEVA_PARTICIPACION, jobMail, {
-                      attempts: 3,
-                    });
 
-                    resolve({ status: 200 });
-                  })
-                  .catch((error) => reject(error));
+            mailUsuarios(NUEVA_PARTICIPACION, rfpMail, cliente)
+              .then((resp) => {
+                resolve(resp);
               })
               .catch((error) => reject(error));
           })
@@ -272,7 +253,7 @@ notificationService.notificacionNuevaParticipacion = (participacion) => {
               .then((resp) => {
                 resolve(resp);
                 /*
-                mailNuevaParticipacion(participacion)
+                mailNuevaParticipacion(detalles, cliente)
                   .then((respMail) => {
                     resolve(respMail);
                   })

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -20,6 +20,7 @@ const mailQueue = require("./MailQueue");
 
 const notificationService = {};
 const SUCCESS_RESP = { success: 1 };
+const MAIL_ENABLED = false;
 
 notificationService.notificacionNuevaOportunidad = (job) => {
   return new Promise((resolve, reject) => {
@@ -33,14 +34,15 @@ notificationService.notificacionNuevaOportunidad = (job) => {
         const detalles = { rfp: job.rfp._id };
         notificacionUsuarios(NUEVA_OPORTUNIDAD, detalles, users)
           .then((resp) => {
-            resolve(resp);
-            /*
-            mailUsuarios(NUEVA_OPORTUNIDAD, job.rfp, users)
-              .then((respMail) => {
-                resolve(respMail);
-              })
-              .catch((error) => reject(error));
-            */
+            if (MAIL_ENABLED) {
+              mailUsuarios(NUEVA_OPORTUNIDAD, job.rfp, users)
+                .then((respMail) => {
+                  resolve(respMail);
+                })
+                .catch((error) => reject(error));
+            } else {
+              resolve(resp);
+            }
           })
           .catch((error) => reject(error));
       })
@@ -100,11 +102,15 @@ notificationService.notificacionCambioEstatusOportunidad = (job) => {
                   nombreOportunidad: rfp.nombreOportunidad,
                   estatus: estatusNuevo,
                 };
-                mailUsuarios(CAMBIO_ESTATUS, rfpData, sociosParticipantes)
-                  .then((respMail) => {
-                    resolve(respMail);
-                  })
-                  .catch((error) => reject(error));
+                if (MAIL_ENABLED) {
+                  mailUsuarios(CAMBIO_ESTATUS, rfpData, sociosParticipantes)
+                    .then((respMail) => {
+                      resolve(respMail);
+                    })
+                    .catch((error) => reject(error));
+                } else {
+                  resolve(resp);
+                }
               })
               .catch((error) => reject(error));
           })
@@ -223,14 +229,15 @@ notificationService.notificacionNuevaParticipacion = (participacion) => {
 
         notificacionUsuarios(NUEVA_PARTICIPACION, detalles, cliente)
           .then((resp) => {
-            resolve(resp);
-            /*
-            mailNuevaParticipacion(detalles, cliente)
-              .then((respMail) => {
-                resolve(respMail);
-              })
-              .catch((error) => reject(error));
-            */
+            if (MAIL_ENABLED) {
+              mailNuevaParticipacion(detalles, cliente)
+                .then((respMail) => {
+                  resolve(respMail);
+                })
+                .catch((error) => reject(error));
+            } else {
+              resolve(resp);
+            }
           })
           .catch((error) => reject(error));
       })
@@ -246,12 +253,16 @@ notificationService.notificacionNuevoEvento = (evento) => {
           return resolve(SUCCESS_RESP);
         }
 
-        // TODO: notificacionUsuarios()... goes here
-        mailNuevoEvento(evento, sociosParticipantes)
-          .then((respMail) => {
-            resolve(respMail);
-          })
-          .catch((error) => reject(error));
+        // TODO: notificacionUsuarios(NUEVO_EVENTO, ...) goes here
+        if (MAIL_ENABLED) {
+          mailNuevoEvento(evento, sociosParticipantes)
+            .then((respMail) => {
+              resolve(respMail);
+            })
+            .catch((error) => reject(error));
+        } else {
+          resolve(SUCCESS_RESP);
+        }
       })
       .catch((error) => reject(error));
   });
@@ -296,12 +307,16 @@ notificationService.notificacionCambioEvento = (eventBeforeUpdate) => {
               return resolve(SUCCESS_RESP);
             }
 
-            // TODO: notificacionUsuarios()... goes here
-            mailCambioEvento(eventBeforeUpdate, eventUpdated, sociosParticipantes)
-              .then((respMail) => {
-                resolve(respMail);
-              })
-              .catch((error) => reject(error));
+            // TODO: notificacionUsuarios(CAMBIO_EVENTO, ...) goes here
+            if (MAIL_ENABLED) {
+              mailCambioEvento(eventBeforeUpdate, eventUpdated, sociosParticipantes)
+                .then((respMail) => {
+                  resolve(respMail);
+                })
+                .catch((error) => reject(error));
+            } else {
+              resolve(SUCCESS_RESP);
+            }
           })
           .catch((error) => reject(error));
       })
@@ -311,7 +326,7 @@ notificationService.notificacionCambioEvento = (eventBeforeUpdate) => {
 
 const mailCambioEvento = function (eventBeforeUpdate, eventUpdated, sociosParticipantes) {
   return new Promise((resolve, reject) => {
-    RfpModel.getNombreOportunidad(eventUpdated.rfp)
+    RfpModel.getNombreOportunidad(eventBeforeUpdate.rfp)
       .then((nombreOportunidad) => {
         const eventData = {
           nombreOportunidad: nombreOportunidad,


### PR DESCRIPTION
Esta PR refactoriza varios métodos de `NotificationService` para evitar redundancias y repetir la misma query a la DB.

En `NotificationService`:
- Se realizan las queries a la DB para obtener destinatarios y datos utilizados por `notificacionUsuarios` y `mailUsuarios` una sola vez antes de llamar a estas funciones.
- Las queries a la DB realizadas en los métodos que crean notificaciones, ahora seleccionan sólo los campos que sean utilizados en los métodos, para hacer el acceso a la DB más eficiente y limpio
- Agrega un check en todas las notificaciones para crear la notificaciones sólo si existen destinatarios para ellas
- Agrega un check en `notificacionCambioEvento` para crear la notificaciones sólo si el evento modificado realmente reflejó cambios en sus valores
- Elimina el doble `resolve()` que se encontraba en `notificacionCambioEstatusOportunidad`
- Elimina las funciones `mailTodosSocios` y `mailParticipantesRfp` y las reemplaza por llamadas a `mailUsuarios`
- Elimina la función `saveDbNotificacionNuevaParticipacion` y se reemplaza por una llamada a `notificacionUsuarios`
- Actualiza `mailNuevaParticipacion` para que utilice una llamada a `mailUsuarios`
- Agrega la flag `MAIL_ENABLED` para des/habilitar el envío de las notificaciones por mail.

En `User.js`:
- Agrega los métodos `findParticipantesByRfp` y `getName`
- Agrega el parámetro opcional `fields` a `findByUserType` y `findByUserTypes` para poder especificar qué campos seleccionar en la query
- Elimina el método `findClientByRFP`, ya que no estaba siendo usado en ningún lado
- El resto de los cambios mostrados en el archivo son por el formatting de Prettier