### PR TITLE
Mail rechazo participación

### DIFF
--- a/server/models/RFP.js
+++ b/server/models/RFP.js
@@ -108,6 +108,19 @@ schema.statics.getNombreOportunidad = function (rfpId) {
   });
 };
 
+schema.statics.getNombreCliente = function (rfpId) {
+  return new Promise((resolve, reject) => {
+    this.findById( rfpId )
+      .then((rfp) => {
+        const nombrecliente = rfp.nombrecliente;
+        resolve(nombrecliente);
+      })
+      .catch((error) => {
+        reject(error);
+      });
+  });
+};
+
 const miRFP = mongoose.model("RFP", schema);
 
 module.exports = miRFP;

--- a/server/services/MailQueue.js
+++ b/server/services/MailQueue.js
@@ -5,7 +5,8 @@ const {
   NUEVA_PARTICIPACION,
   NUEVO_EVENTO,
   CAMBIO_EVENTO,
-  CAMBIO_ESTATUS
+  CAMBIO_ESTATUS,
+  PARTICIPACION_RECHAZADA,
 } = require("../utils/NotificationTypes");
 const mailService = require("./MailService");
 
@@ -28,6 +29,10 @@ mailQueue.process(CAMBIO_EVENTO, (job) => {
 });
 
 mailQueue.process(CAMBIO_ESTATUS, (job) => {
+  return mailService.sendEmail(job.data);
+});
+
+mailQueue.process(PARTICIPACION_RECHAZADA, (job) => {
   return mailService.sendEmail(job.data);
 });
 

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -6,7 +6,8 @@ const {
   NUEVA_PARTICIPACION,
   NUEVO_EVENTO,
   CAMBIO_EVENTO,
-  CAMBIO_ESTATUS
+  CAMBIO_ESTATUS,
+  PARTICIPACION_RECHAZADA
 } = require("../utils/NotificationTypes");
 
 var options = { format: "Letter" };
@@ -58,6 +59,7 @@ mailService.sendEmail = (jobData) => {
 };
 
 mailService.buildMailContent = (tipoNotificacion, mailData) => {
+  console.log("entro a build mail content");
   return new Promise((resolve, reject) => {
     let mailOptions = {};
 
@@ -156,6 +158,11 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
         mailOptions.subject = "Cambio de estatus en la Oportunidad Comercial";
         mailOptions.text = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" de "${mailData.estatusPrevio}" a "${mailData.estatusNuevo}".`;
         mailOptions.html = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" de "${mailData.estatusPrevio}" a "${mailData.estatusNuevo}".</p>`;
+        break;
+      case PARTICIPACION_RECHAZADA:
+        mailOptions.subject = "Participación Rechazada en Oportunidad Comercial";
+        mailOptions.text = `Lamentamos informarle que el cliente ${mailData.nombreCliente} ha rechazado su propuesta para la oportunidad "${mailData.nombreOportunidad}".`;
+        mailOptions.html = `Lamentamos informarle que el cliente ${mailData.nombreCliente} ha rechazado su propuesta para la oportunidad "${mailData.nombreOportunidad}".</p>`;
         break;
 
       default:

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -10,7 +10,6 @@ const {
   PARTICIPACION_RECHAZADA
 } = require("../utils/NotificationTypes");
 
-var options = { format: "Letter" };
 const mailService = {};
 
 var mailConfig = {
@@ -159,10 +158,15 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
         mailOptions.text = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" de "${mailData.estatusPrevio}" a "${mailData.estatusNuevo}".`;
         mailOptions.html = `queremos informarte que el cliente ${mailData.nombreCliente} ha cambiado el estatus de la oportunidad "${mailData.nombreOportunidad}" de "${mailData.estatusPrevio}" a "${mailData.estatusNuevo}".</p>`;
         break;
+
       case PARTICIPACION_RECHAZADA:
         mailOptions.subject = "Participación Rechazada en Oportunidad Comercial";
-        mailOptions.text = `Lamentamos informarle que el cliente ${mailData.nombreCliente} ha rechazado su propuesta para la oportunidad "${mailData.nombreOportunidad}".`;
-        mailOptions.html = `Lamentamos informarle que el cliente ${mailData.nombreCliente} ha rechazado su propuesta para la oportunidad "${mailData.nombreOportunidad}".</p>`;
+        mailOptions.text = `lamentamos informarte que el cliente ${mailData.nombreCliente} ha rechazado tu propuesta para la oportunidad "${mailData.nombreOportunidad}".
+        Te presentamos el feedback que el cliente proporcionó acerca tu participación en su oportunidad:
+        "${mailData.feedback}"`;
+        mailOptions.html = `lamentamos informarte que el cliente ${mailData.nombreCliente} ha rechazado tu propuesta para la oportunidad "${mailData.nombreOportunidad}".</p>
+        <p>Te presentamos el feedback que el cliente proporcionó acerca de tu participación en su oportunidad:<br>
+        "${mailData.feedback}"</p>`;
         break;
 
       default:
@@ -191,6 +195,7 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
 
 const generatePdf = (bodyTitle, htmlBody) => {
   return new Promise((resolve, reject) => {
+    const options = { format: "Letter" };
     htmlToPdf = `
     <!doctype html>
     <html>

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -7,7 +7,7 @@ const {
   NUEVO_EVENTO,
   CAMBIO_EVENTO,
   CAMBIO_ESTATUS,
-  PARTICIPACION_RECHAZADA
+  PARTICIPACION_RECHAZADA,
 } = require("../utils/NotificationTypes");
 
 const mailService = {};
@@ -17,12 +17,12 @@ var mailConfig = {
   pool: true,
   auth: {
     user: process.env.MAIL_USER,
-    pass: process.env.MAIL_PASSWORD
+    pass: process.env.MAIL_PASSWORD,
   },
 };
 
 var transporter = nodemailer.createTransport(mailConfig, {
-  from: `Oportunidades Comerciales CSOFTMTY <${process.env.MAIL_USER}>`
+  from: `Oportunidades Comerciales CSOFTMTY <${process.env.MAIL_USER}>`,
 });
 
 // email sender function
@@ -34,14 +34,14 @@ mailService.sendEmail = (jobData) => {
       to: destinatario.email,
       subject: mailContent.subject,
       text: `Hola ${destinatario.name}, ${mailContent.text}`,
-      html: `<p>Hola ${destinatario.name}, ${mailContent.html}`
+      html: `<p>Hola ${destinatario.name}, ${mailContent.html}`,
     };
 
     if (mailContent.attachments) {
       mailOptions.attachments = {
         filename: mailContent.attachments.filename,
         content: mailContent.attachments.content,
-        encoding: "base64"
+        encoding: "base64",
       };
     }
 
@@ -67,21 +67,21 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
         mailOptions.subject = "Nueva Oportunidad Comercial";
         mailOptions.text = `te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:
 
-        Nombre de la Oportunidad Comercial: ${mailData.nombreOportunidad}
-        Objetivo de la oportunidad: ${mailData.objetivoOportunidad}
-        Descripción funcional de la oportunidad: ${mailData.descripcionFuncional}
-        Requerimientos obligatorios: ${mailData.requerimientosObligatorios}
-        Fechas relevantes: ${mailData.fechasRelevantes}
-        ¿Ha sido aprobada por el área usuaria?: ${mailData.aprobadaAreaUsuario}
-        ¿Ha sido aprobada por el área de TI?: ${mailData.aprobadaAreaTI}
-        ¿Tiene un presupuesto asignado?: ${mailData.presupuestoAsignado}
-        Tipo general del proyecto: ${mailData.tipoGeneralProyecto}
-        Tipo específico del proyecto: ${mailData.tipoEspecificoProyecto}
-        Comentarios adicionales: ${mailData.comentariosAdicionales}
+Nombre de la Oportunidad Comercial: ${mailData.nombreOportunidad}
+Objetivo de la oportunidad: ${mailData.objetivoOportunidad}
+Descripción funcional de la oportunidad: ${mailData.descripcionFuncional}
+Requerimientos obligatorios: ${mailData.requerimientosObligatorios}
+Fechas relevantes: ${mailData.fechasRelevantes}
+¿Ha sido aprobada por el área usuaria?: ${mailData.aprobadaAreaUsuario}
+¿Ha sido aprobada por el área de TI?: ${mailData.aprobadaAreaTI}
+¿Tiene un presupuesto asignado?: ${mailData.presupuestoAsignado}
+Tipo general del proyecto: ${mailData.tipoGeneralProyecto}
+Tipo específico del proyecto: ${mailData.tipoEspecificoProyecto}
+Comentarios adicionales: ${mailData.comentariosAdicionales}
 
-        Datos de contacto
-        Nombre: ${mailData.nombrecliente}
-        Posición: ${mailData.posicioncliente}`;
+Datos de contacto
+Nombre: ${mailData.nombrecliente}
+Posición: ${mailData.posicioncliente}`;
 
         mailOptions.html = `<h3>Datos generales</h3>
         <p><b>Nombre de la Oportunidad Comercial:</b> ${mailData.nombreOportunidad}<br>
@@ -114,9 +114,9 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
 
         mailOptions.subject = "Nueva junta para Oportunidad Comercial";
         mailOptions.text = `se ha agendado una nueva junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:
-        Nombre: ${mailData.name}
-        Fecha: ${eventDate}
-        Liga de la reunión: ${mailData.link}`;
+Nombre: ${mailData.name}
+Fecha: ${eventDate}
+Liga de la reunión: ${mailData.link}`;
 
         mailOptions.html = `se ha agendado una nueva junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:</p>
         <p><b>Nombre:</b> ${mailData.name}<br>
@@ -133,14 +133,14 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
 
         mailOptions.subject = "Cambio en junta para Oportunidad Comercial";
         mailOptions.text = `se han hecho cambios en una junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:
-        Datos actualizados:
-        Nombre: ${mailData.eventUpdated.name}
-        Fecha: ${dateEventUpdated}
-        Liga de la reunión: ${mailData.eventUpdated.link}
-        Datos antiguos:
-        Nombre: ${mailData.eventBeforeUpdate.name}
-        Fecha: ${dateEventBeforeUpdate}
-        Liga de la reunión: ${mailData.eventBeforeUpdate.link}`;
+Datos actualizados:
+Nombre: ${mailData.eventUpdated.name}
+Fecha: ${dateEventUpdated}
+Liga de la reunión: ${mailData.eventUpdated.link}
+Datos antiguos:
+Nombre: ${mailData.eventBeforeUpdate.name}
+Fecha: ${dateEventBeforeUpdate}
+Liga de la reunión: ${mailData.eventBeforeUpdate.link}`;
 
         mailOptions.html = `se han hecho cambios en una junta para la Oportunidad Comercial "${mailData.nombreOportunidad}" en la cual estás participando:</p>
         <h3>Datos actualizados:</h3>
@@ -162,8 +162,8 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
       case PARTICIPACION_RECHAZADA:
         mailOptions.subject = "Participación Rechazada en Oportunidad Comercial";
         mailOptions.text = `lamentamos informarte que el cliente ${mailData.nombreCliente} ha rechazado tu propuesta para la oportunidad "${mailData.nombreOportunidad}".
-        Te presentamos el feedback que el cliente proporcionó acerca tu participación en su oportunidad:
-        "${mailData.feedback}"`;
+Te presentamos el feedback que el cliente proporcionó acerca tu participación en su oportunidad:
+"${mailData.feedback}"`;
         mailOptions.html = `lamentamos informarte que el cliente ${mailData.nombreCliente} ha rechazado tu propuesta para la oportunidad "${mailData.nombreOportunidad}".</p>
         <p>Te presentamos el feedback que el cliente proporcionó acerca de tu participación en su oportunidad:<br>
         "${mailData.feedback}"</p>`;
@@ -179,14 +179,18 @@ mailService.buildMailContent = (tipoNotificacion, mailData) => {
     <img src="https://www.csoftmty.org/assets/images/header/logo.png" alt="logo_csoftmty"/>`;
 
     if (tipoNotificacion === NUEVA_OPORTUNIDAD) {
-      generatePdf("Nueva Oportunidad Comercial", mailOptions.html).then((base64String) => {
-        mailOptions.attachments = {
-          filename: `${mailData.nombreOportunidad}.pdf`,
-          content: base64String,
-        };
-        mailOptions.html = "te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:" + mailOptions.html;
-        resolve(mailOptions);
-      });
+      generatePdf("Nueva Oportunidad Comercial", mailOptions.html)
+        .then((base64String) => {
+          mailOptions.attachments = {
+            filename: `${mailData.nombreOportunidad}.pdf`,
+            content: base64String,
+          };
+          mailOptions.html =
+            "te comunicamos que se ha abierto una nueva Oportunidad Comercial, te compartimos los detalles:" +
+            mailOptions.html;
+          resolve(mailOptions);
+        }
+      );
     } else {
       resolve(mailOptions);
     }

--- a/server/services/MailService.js
+++ b/server/services/MailService.js
@@ -58,7 +58,6 @@ mailService.sendEmail = (jobData) => {
 };
 
 mailService.buildMailContent = (tipoNotificacion, mailData) => {
-  console.log("entro a build mail content");
   return new Promise((resolve, reject) => {
     let mailOptions = {};
 

--- a/server/services/NotificationService.js
+++ b/server/services/NotificationService.js
@@ -155,6 +155,30 @@ notificationService.notificacionParticipacionRechazada = (job) => {
   });
 };
 
+const mailRechazoParticipacion = function (participacion, socio) {
+  return new Promise((resolve, reject) => {
+    const rfpId = participacion.rfpInvolucrado;
+    RfpModel.getNombreOportunidad(rfpId)
+      .then((nombreOportunidad) => {
+        RfpModel.getNombreCliente(rfpId)
+          .then((nombreCliente) => {
+            const participacionData = {
+              nombreCliente: nombreCliente,
+              nombreOportunidad: nombreOportunidad,
+              feedback: participacion.feedback,
+            };
+            mailUsuarios(PARTICIPACION_RECHAZADA, participacionData, socio)
+              .then((respMail) => {
+                resolve(respMail);
+              })
+              .catch((error) => reject(error));
+          })
+          .catch((error) => reject(error));
+      })
+      .catch((error) => reject(error));
+  });
+};
+
 const notificacionUsuarios = function (tipoNotificacion, detalles, socios) {
   return new Promise((resolve, reject) => {
     detallesNotifController
@@ -201,30 +225,6 @@ const notificacionUsuarios = function (tipoNotificacion, detalles, socios) {
       .catch((error) => {
         reject(error);
       });
-  });
-};
-
-const mailRechazoParticipacion = function (participacion, socio) {
-  return new Promise((resolve, reject) => {
-    const rfpId = participacion.rfpInvolucrado;
-    RfpModel.getNombreOportunidad(rfpId)
-      .then((nombreOportunidad) => {
-        RfpModel.getNombreCliente(rfpId)
-          .then((nombreCliente) => {
-            const participacionData = {
-              nombreCliente: nombreCliente,
-              nombreOportunidad: nombreOportunidad,
-              feedback: participacion.feedback
-            };
-            mailUsuarios(PARTICIPACION_RECHAZADA, participacionData, socio)
-              .then((respMail) => {
-                resolve(respMail);
-              })
-              .catch((error) => reject(error));
-          })
-          .catch((error) => reject(error));
-      })
-      .catch((error) => reject(error));
   });
 };
 


### PR DESCRIPTION
Este PR:
- Agrega los mails de notificación para `PARTICIPIACION_RECHAZADA`, que recibe un socio cuando un cliente lo rechaza en su Oportunidad Comercial. El mail incluye el feedback que el cliente proporcionó al rechazar al socio.
- Agrega `getNombreCliente` en `RFP.js`

Así se ve el mail enviado:
![image](https://user-images.githubusercontent.com/23624317/116490865-1a813680-a85e-11eb-8789-3b1eb390f33c.png)