### PR TITLE
Adding winner selection functionality

### DIFF
--- a/client/src/components/Cards/SocioInvolucradoCard.js
+++ b/client/src/components/Cards/SocioInvolucradoCard.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Button, Card, CardContent, Typography } from "@material-ui/core";
-import { obtenerListaInvolucrados } from "../../fetchers/fetcher";
+import { obtenerSocio } from "../../fetchers/fetcher";
 
 const useStyles = makeStyles({
   title: {
@@ -40,7 +40,7 @@ export default function SimpleCard({
 
   useEffect(() => {
     if (userType === "admin" || userType === "cliente") {
-      obtenerListaInvolucrados(user)
+      obtenerSocio(user)
         .then((data) => {
           setSocioData({
             nombre: data.name,

--- a/client/src/components/Dialogs/AceptarPropuesta.js
+++ b/client/src/components/Dialogs/AceptarPropuesta.js
@@ -1,0 +1,197 @@
+import React, { useState, useEffect } from "react";
+import { withStyles } from "@material-ui/core/styles";
+import {
+  Button,
+  Dialog,
+  FormControl,
+  IconButton,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import MuiDialogTitle from "@material-ui/core/DialogTitle";
+import CloseIcon from "@material-ui/icons/Close";
+import {
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  DialogContent,
+  DialogActions,
+} from "@material-ui/core";
+import { actualizarEstatusSocio, obtenerSocio } from "../../fetchers/fetcher";
+
+const styles = (theme) => ({
+  root: {
+    margin: 0,
+    padding: theme.spacing(2),
+  },
+  closeButton: {
+    position: "absolute",
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+  labeledTextContainer: {
+    display: "flex",
+    flexDirection: "row",
+  },
+  boldLabel: {
+    fontSize: 16,
+    fontWeight: 700,
+  },
+  labeledInfoText: {
+    fontSize: 16,
+  },
+});
+
+const DialogTitle = withStyles(styles)((props) => {
+  const { children, classes, onClose, ...other } = props;
+  return (
+    <MuiDialogTitle disableTypography className={classes.root} {...other}>
+      <Typography variant="h6">{children}</Typography>
+      {onClose ? (
+        <IconButton
+          aria-label="close"
+          className={classes.closeButton}
+          onClick={onClose}
+        >
+          <CloseIcon />
+        </IconButton>
+      ) : null}
+    </MuiDialogTitle>
+  );
+});
+
+export default function AceptarPropuesta(props) {
+  const [reason, setReason] = useState("");
+  const [markedSure, setMarkedSure] = useState(false);
+  const [participacionWinnerId, setParticipacionWinnerId] = useState("");
+  const [listaSocioParticipacion, setListaSocioParticipacion] = useState({});
+
+  useEffect(() => {
+    props.listaParticipaciones.forEach((participacion) => {
+      obtenerSocio(participacion.socioInvolucrado).then((res) => {
+        if (participacion.socioEstatus === "Activo") {
+          const newSocio = {
+            [participacion._id]: res.name,
+          };
+          setListaSocioParticipacion((prev) => {
+            return { ...prev, ...newSocio };
+          });
+          setParticipacionWinnerId(participacion._id);
+        }
+      });
+    });
+  }, []);
+
+  const handleClose = () => {
+    props.setIsModalOpen(false);
+  };
+
+  const handleChangeWinner = (e) => {
+    e.preventDefault();
+    setParticipacionWinnerId(e.target.value);
+  };
+
+  const handleSend = (e) => {
+    e.preventDefault();
+    actualizarEstatusSocio(participacionWinnerId, "Ganador", reason);
+    Object.keys(listaSocioParticipacion).forEach((participation_id) => {
+      if (participation_id !== participacionWinnerId) {
+        // TODO: What would be the default feedback?
+        actualizarEstatusSocio(participation_id, "Rechazado", "");
+      }
+    });
+    window.location.reload();
+  };
+
+  const onReasonChange = (e) => {
+    setReason(e.target.value);
+  };
+
+  const onConfirmToggle = (e) => {
+    setMarkedSure(e.target.checked);
+  };
+
+  const isSendDisabled = () => {
+    return reason.length < 1 || !markedSure;
+  };
+
+  return (
+    <div>
+      <Dialog
+        onClose={handleClose}
+        aria-labelledby="customized-dialog-title"
+        open={props.isOpen}
+      >
+        <DialogTitle id="customized-dialog-title" onClose={handleClose}>
+          Aceptar Propuesta de Socio
+        </DialogTitle>
+        <DialogContent dividers>
+          <FormGroup>
+            <div style={{ display: "flex" }}>
+              <Typography
+                style={{ fontSize: 16, fontWeight: 700, marginRight: "0.5em" }}
+              >
+                Nombre de la Oportunidad:
+              </Typography>
+              <Typography style={{ fontSize: 16 }}>
+                {props.opportunityName}
+              </Typography>
+            </div>
+            <div style={{ display: "flex" }}>
+              <Typography
+                style={{ fontSize: 16, fontWeight: 700, marginRight: "0.5em" }}
+              >
+                Nombre del Socio Ganador:
+              </Typography>
+              <FormControl>
+                <Select
+                  value={participacionWinnerId}
+                  onChange={handleChangeWinner}
+                >
+                  {Object.keys(listaSocioParticipacion).map(
+                    (participacionId) => {
+                      return (
+                        <MenuItem value={participacionId} key={participacionId}>
+                          {listaSocioParticipacion[participacionId]}
+                        </MenuItem>
+                      );
+                    }
+                  )}
+                </Select>
+              </FormControl>
+            </div>
+            <TextField
+              label="Retroalimentación"
+              multiline
+              rows={4}
+              variant="outlined"
+              margin="normal"
+              fullWidth
+              value={reason}
+              onChange={onReasonChange}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox checked={markedSure} onChange={onConfirmToggle} />
+              }
+              label="Estoy seguro de que quiero aceptar la propuesta de este socio y rechazar las del resto de los participantes"
+            />
+          </FormGroup>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            autoFocus
+            onClick={handleSend}
+            color="primary"
+            disabled={isSendDisabled()}
+          >
+            MANDAR RETROALIMENTACIÓN
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/components/pages/Detalle.js
+++ b/client/src/components/pages/Detalle.js
@@ -1,13 +1,23 @@
 import React, { useState, useEffect } from "react";
 import { useMatch } from "react-router-dom";
-import { Card, CircularProgress, Grid, Typography } from "@material-ui/core";
+import {
+  Button,
+  Card,
+  CircularProgress,
+  Grid,
+  Typography,
+} from "@material-ui/core";
 import axios from "axios";
 import "../../styles/globalStyles.css";
 import SideMenu from "../SideMenu/SideMenu";
 import RfpCardDetalle from "../Cards/RfpCardDetalle";
 import SocioInvolucradoCard from "../Cards/SocioInvolucradoCard";
 import RechazarPropuesta from "../Dialogs/RechazarPropuesta";
-import { obtenerRFP } from "../../fetchers/fetcher";
+import {
+  obtenerRFP,
+  obtenerListaParticipaciones,
+} from "../../fetchers/fetcher";
+import AceptarPropuesta from "../Dialogs/AceptarPropuesta";
 
 const Inicio = ({ route }) => {
   let match = useMatch("/detalle/:rfp_id");
@@ -21,8 +31,10 @@ const Inicio = ({ route }) => {
   );
   // state de control de si ya se hizo la llamada de RFP a la base de datos
   const [llamadaRFP, guardarLlamadaRFP] = useState(false);
-  // state de control de si el modal de retroalimentación está abierto
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  // state de control de si el modal de rechazo de socio está abierto
+  const [isRejectModalOpen, setIsRejectModalOpen] = useState(false);
+  // state de control de si el modal de socio ganador está abierto
+  const [isAcceptModalOpen, setIsAcceptModalOpen] = useState(false);
   // state con el nombre del socio que esta siendo rechazado
   const [socioRechazado, setSocioRechazado] = useState({});
   // state con el estado de participación
@@ -37,29 +49,13 @@ const Inicio = ({ route }) => {
         "Content-Type": "application/json",
       },
     };
-    const obtenerListaInvolucrados = () => {
-      axios
-        .get(
-          "/participacion/get-participaciones-rfp/" + match.params.rfp_id,
-          config
-        )
-        .then((res) => {
-          // guardar lista de participaciones en state
-          guardarListaParticipaciones(res.data);
-          // actualizar variable de control
-          guardarLlamadaParticipaciones(true);
-        })
-        .catch((error) => {
-          console.log(error);
-        });
-    };
     const obtenerEstatusParticipacion = () => {
       axios
         .get("/participacion/get-participaciones-socio", config)
         .then((res) => {
           let isParticipating = false;
           for (const idx in res.data) {
-            if(res.data[idx].rfpInvolucrado === match.params.rfp_id) {
+            if (res.data[idx].rfpInvolucrado === match.params.rfp_id) {
               isParticipating = true;
             }
           }
@@ -75,8 +71,18 @@ const Inicio = ({ route }) => {
         console.log(error);
       });
 
-    if (userType === "admin") obtenerListaInvolucrados();
-    if (userType === "cliente") obtenerListaInvolucrados();
+    if (userType === "admin" || userType == "cliente") {
+      obtenerListaParticipaciones(match.params.rfp_id)
+        .then((res) => {
+          // guardar lista de participaciones en state
+          guardarListaParticipaciones(res);
+          // actualizar variable de control
+          guardarLlamadaParticipaciones(true);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    }
     if (userType === "socio") obtenerEstatusParticipacion();
   }, []);
 
@@ -87,7 +93,22 @@ const Inicio = ({ route }) => {
       participacionId: participacionId,
       estatus: estatus,
     });
-    setIsModalOpen(true);
+    setIsRejectModalOpen(true);
+  };
+
+  const handleChooseWinner = (e) => {
+    e.preventDefault();
+    setIsAcceptModalOpen(true);
+  };
+
+  const hasValidCandidates = () => {
+    let ans = false;
+    let hasWinner = false;
+    listaParticipaciones.forEach((participation) => {
+      if (participation.socioEstatus === "Ganador") hasWinner = true;
+      else if (participation.socioEstatus === "Activo") ans = true;
+    });
+    return !hasWinner && ans;
   };
 
   return (
@@ -98,15 +119,27 @@ const Inicio = ({ route }) => {
         {!llamadaRFP ? (
           <CircularProgress color="secondary" />
         ) : (
-          <RfpCardDetalle key={match.params.rfp_id} rfp={RFP} isParticipating={isParticipating} />
+          <RfpCardDetalle
+            key={match.params.rfp_id}
+            rfp={RFP}
+            isParticipating={isParticipating}
+          />
         )}
         <RechazarPropuesta
-          setIsModalOpen={setIsModalOpen}
-          isOpen={isModalOpen}
+          setIsModalOpen={setIsRejectModalOpen}
+          isOpen={isRejectModalOpen}
           opportunityName={RFP.nombreOportunidad}
           socioName={socioRechazado.name}
           participacionId={socioRechazado.participacionId}
         />
+        {llamadaParticipaciones ? (
+          <AceptarPropuesta
+            setIsModalOpen={setIsAcceptModalOpen}
+            isOpen={isAcceptModalOpen}
+            opportunityName={RFP.nombreOportunidad}
+            listaParticipaciones={listaParticipaciones}
+          />
+        ) : null}
         {userType === "socio" ? null : (
           <Grid container direction="row" className="container-dashboard ">
             {llamadaParticipaciones ? (
@@ -119,6 +152,16 @@ const Inicio = ({ route }) => {
               ) : (
                 <Card className="cardHaySocios">
                   <Typography>Socios involucrados:</Typography>
+                  {hasValidCandidates() ? (
+                    <Button
+                      size="small"
+                      onClick={(e) => {
+                        handleChooseWinner(e);
+                      }}
+                    >
+                      SELECCIONAR GANADOR
+                    </Button>
+                  ) : null}
                 </Card>
               )
             ) : null}

--- a/client/src/fetchers/fetcher.js
+++ b/client/src/fetchers/fetcher.js
@@ -17,12 +17,28 @@ function updateConfig() {
   config = currentConfig;
 }
 
-async function obtenerListaInvolucrados(user) {
+async function obtenerSocio(user) {
   updateConfig();
   const response = await axios
     .get("/user/get-socio/" + user, config)
     .then((res) => {
       return res.data.user;
+    })
+    .catch((error) => {
+      return error;
+    });
+  return response;
+}
+
+async function obtenerListaParticipaciones(rfp_id) {
+  updateConfig();
+  const response = await axios
+    .get(
+      "/participacion/get-participaciones-rfp/" + rfp_id,
+      config
+    )
+    .then((res) => {
+      return res.data;
     })
     .catch((error) => {
       return error;
@@ -62,4 +78,4 @@ async function actualizarEstatusSocio(participacionId, estatus, feedback) {
     });
 }
 
-export { obtenerListaInvolucrados, obtenerRFP, actualizarEstatusSocio };
+export { obtenerSocio, obtenerRFP, actualizarEstatusSocio, obtenerListaParticipaciones };

--- a/client/src/styles/globalStyles.css
+++ b/client/src/styles/globalStyles.css
@@ -316,9 +316,10 @@
    align-items: center;
 }
 .cardHaySocios {
-   width: 200px;
-   height: 50px;
+   width: 250px;
+   height: 75px;
    display: flex;
+   flex-direction: column;
    justify-content: center;
    align-items: center;
 }


### PR DESCRIPTION
Este PR agrega lo siguiente:
- Botón para escoger un ganador en caso de que no se haya escogido a uno y que haya al menos un socio en estatus "Activo"
- Modal para escoger un ganador con las siguientes características:
   - Muestra el nombre de la oportunidad
   - Muestra un menú de selección con los nombres de los socios que aún pueden ser elegidos
   - Muestra una sección de retroalimentación y de confirmación, ambas obligatorias
- Al escoger a un ganador, se rechaza a los socios que aún podían ser elegidos con una retroalimentación vacía (podemos poner un texto predeterminado) y se cambia el estatus del ganador, se recarga la página y ya no aparece el botón para escoger a un ganador