### PR TITLE
Toggle read button in database for notification list

### DIFF
--- a/client/src/components/SideMenu/NotificationFactory.js
+++ b/client/src/components/SideMenu/NotificationFactory.js
@@ -194,7 +194,6 @@ class PortalNotification extends Component {
   };
 
   toggleRead = () => {
-    // TODO: One-way call to the backend to update the bd
     if (!this.state.toggledRead) {
       this.setState({
         toggledRead: true,
@@ -205,6 +204,24 @@ class PortalNotification extends Component {
         isRead: !this.state.isRead,
       });
     }
+
+    const config = {
+      headers: {
+        Authorization: "Bearer " + sessionStorage.getItem("token"),
+        "Content-Type": "application/json",
+      },
+      params:{
+        id: this.state.data.id,
+      },
+    }
+    axios
+    .patch("/notificaciones/toggle-is-read",{},config)
+    .then((res)=>{
+
+    })
+    .catch((error)=>{
+      console.log(error);
+    });
   };
 
   deleteNotification = (id) => {

--- a/server/controllers/UsuarioNotificacionController.js
+++ b/server/controllers/UsuarioNotificacionController.js
@@ -35,4 +35,14 @@ usuarioNotificacion.deleteUsuarioNotificacion = (id) => {
   });
 };
 
+usuarioNotificacion.toggleRead = (id) => {
+  return new Promise ((resolve, reject) => {
+    UsuarioNotificacion.findByIdAndUpdate(id,{read:true})
+    .then((notif)=>{
+      resolve(notif);
+    })
+    .catch((error)=>reject(error));
+  })
+}
+
 module.exports = usuarioNotificacion;

--- a/server/routes/usuarioNotificacionapi.js
+++ b/server/routes/usuarioNotificacionapi.js
@@ -21,4 +21,15 @@ router.delete("/delete-usuario-notificacion", userMiddleware, (req, res) => {
     });
 });
 
+router.patch("/toggle-is-read", userMiddleware, (req, res) => {
+  usuarioNotificacionController
+  .toggleRead(req.query.id)
+  .then(() => {
+    return res.send({ success: 1 });
+  })
+  .catch((error) => {
+    return res.status(400).send({ success: 0, error });
+  });
+});
+
 module.exports = router;


### PR DESCRIPTION
Esta PR incluye el endpoint para cambiar el valor de "read" a true en la base de datos para cada notificación enlistada en la interfaz al hacer click en el círculo. Una vez realizado el click, el estatus de leído es consistente. 