### PR TITLE
Fixed crypto randombytes to original file names

### DIFF
--- a/client/src/components/Cards/RfpCardDetalle.js
+++ b/client/src/components/Cards/RfpCardDetalle.js
@@ -37,7 +37,8 @@ export default function SimpleCard({ rfp, isParticipating }) {
     formData.append( 
       "file",
       selectedFile,
-      selectedFile.name
+      selectedFile.name,
+      selectedFile.originalname,
     );
 
     axios.post("/participacion/upload-file", formData, config)

--- a/server/controllers/ParticipacionFileController.js
+++ b/server/controllers/ParticipacionFileController.js
@@ -3,15 +3,15 @@ const Participacion = require("../models/Participaciones");
 
 const participacionFile = {};
 
-participacionFile.createParticipacionFile = (rfpInvolucrado, socioInvolucrado, filename) => {
+participacionFile.createParticipacionFile = (rfpInvolucrado, socioInvolucrado, filename, originalname) => {
   return new Promise((resolve, reject) => {
     Participacion.findOne({ rfpInvolucrado: rfpInvolucrado, socioInvolucrado: socioInvolucrado }, "_id")
       .then((participacion) => {
         const rawParticipacionFile = {
           participacion: participacion._id,
-          name: filename
+          name: filename,
+          originalname: originalname,
         }
-
         const participacionFile = new ParticipacionFile(rawParticipacionFile);
         participacionFile
           .save()
@@ -26,10 +26,10 @@ participacionFile.createParticipacionFile = (rfpInvolucrado, socioInvolucrado, f
 
 participacionFile.getFilesFromParticipacion = (participacionId) => {
   return new Promise((resolve, reject) => {
-    ParticipacionFile.find({ participacion: participacionId }, "name")
+    ParticipacionFile.find({ participacion: participacionId }, "originalname")
       .then((files) => {
         const filenames = files.map((file) => {
-          return file.name;
+          return file.originalname;
         });
         resolve(filenames);
       })

--- a/server/models/ParticipacionFile.js
+++ b/server/models/ParticipacionFile.js
@@ -5,6 +5,10 @@ const schema = new mongoose.Schema({
     type: String,
   },
 
+  originalname:{
+    type: String,
+  },
+
   participacion: {
     type: mongoose.Schema.Types.ObjectId,
     ref: "participaciones",

--- a/server/routes/participacionapi.js
+++ b/server/routes/participacionapi.js
@@ -32,6 +32,7 @@ const storage = GridFsStorage({
         const fileInfo = {
           filename: filename,
           bucketName: FILE_COLLECTION,
+          aliases:file.originalname
         };
         resolve(fileInfo);
       });
@@ -147,7 +148,7 @@ router.post(
   [userMiddleware, upload.single("file")],
   (req, res) => {
     if (req.file) {
-      ParticipacionFileController.createParticipacionFile(req.query.rfpInvolucrado, req.user._id, req.file.filename)
+      ParticipacionFileController.createParticipacionFile(req.query.rfpInvolucrado, req.user._id, req.file.filename,req.file.originalname)
         .then(() => {
           return res.send({ file: req.file });
         })
@@ -165,7 +166,7 @@ router.post(
  * @param {Object} res respuesta del request
  */
 router.get('/get-file/:filename', userMiddleware, (req, res) => {
-  gfs.files.findOne({ filename: req.params.filename }, (err, file) => {
+  gfs.files.findOne({ aliases: req.params.filename }, (err, file) => {
     if (!file || file.length === 0) {
       return res.status(404).json({
         err: 'No file exists'
@@ -182,7 +183,7 @@ router.get('/get-file/:filename', userMiddleware, (req, res) => {
  * @param {Object} res respuesta del request
  */
 router.get('/get-base64-file/:filename', userMiddleware, (req, res) => {
-  gfs.files.findOne({ filename: req.params.filename }, (err, file) => {
+  gfs.files.findOne({ aliases: req.params.filename }, (err, file) => {
     if (!file || file.length === 0) {
       return res.status(404).json({
         err: 'No file exists'


### PR DESCRIPTION
Los nombres mostrados en las Cards de Socios Involucrados son los nombres originales con los que se subieron a la plataforma.

El modelo de "ParticipacionFiles" en la base de datos mantiene el nombre generado por crypto.randomBytes como "name" y el nombre tal cual del archivo como "originalname".

La colección de fileUploads.file también contiene ahora el nombre del archivo original para poder localizarlo y permitir la descarga. 
