### PR TITLE
Clickable links for event meetings

### DIFF
--- a/client/src/components/Cards/EventoCliente.js
+++ b/client/src/components/Cards/EventoCliente.js
@@ -34,6 +34,13 @@ export default function EventoCliente({ evento }) {
   const [link, guardarLink] = useState(evento.link);
   const [id, guardarId] = useState(evento._id);
 
+  //Validar si link tiene http/https
+  if (!/^https?:\/\//i.test(link)) {
+    var url = 'https://' + link;
+  }
+  else{
+    url = link;
+  }
   // State del modal de editar evento
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const handleEditClick = () => {
@@ -104,8 +111,8 @@ export default function EventoCliente({ evento }) {
         </div>
         <div className={classes.containerText}>
           <Typography className={classes.labelText}>Link:</Typography>
-          <Link href={link} target="_blank">
-            {link}
+          <Link href={url} target="_blank">
+            {url}
           </Link>
         </div>
       </div>

--- a/client/src/components/Cards/EventoSocio.js
+++ b/client/src/components/Cards/EventoSocio.js
@@ -34,6 +34,13 @@ export default function EventoSocio({evento}) {
   // Opciones para mostrar la fecha en string
   const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
 
+  //validar si link contiene http/https
+  if (!/^https?:\/\//i.test(evento.link)) {
+    var url = 'https://' + evento.link;
+  }
+  else{
+    url = evento.link;
+  }
   return (
     <>
       <div className="container-evento">
@@ -45,8 +52,8 @@ export default function EventoSocio({evento}) {
           {' '}
           {moment.utc(evento.fecha).toDate().toLocaleTimeString('en-US')}
         </Typography>
-        <Link href={evento.link} target="_blank">
-          {evento.link}
+        <Link href={url} target="_blank">
+          {url}
         </Link>
       </div>
     </>

--- a/client/src/components/Dialogs/CalendarEventDetails.js
+++ b/client/src/components/Dialogs/CalendarEventDetails.js
@@ -16,6 +16,14 @@ import useStyles from "./styles";
 export default function CalendarEventDetails(params) {
   const classes = useStyles();
 
+//Validar si link tiene http/https
+  if (!/^https?:\/\//i.test(params.selectedEventLink)) {
+    var url = 'https://' + params.selectedEventLink;
+  }
+  else{
+    url = params.selectedEventLink;
+  }
+
   return (
     <div>
       <Dialog
@@ -66,9 +74,9 @@ export default function CalendarEventDetails(params) {
             <Typography className={classes.labelText}>
               Liga del Evento:
             </Typography>
-            <Typography className={classes.valueText}>
-              {params.selectedEventLink}
-            </Typography>
+            <a className={classes.valueText} href={url}>
+              {url}
+            </a>
           </div>
         </DialogContent>
 


### PR DESCRIPTION
Este PR incluye hacer clickeables los links del calendario.
Además valida si el string contiene http o https y agregarlo en caso que no lo contengan, para poder navegar al sitio correspondiente haciendo click en el enlace. 